### PR TITLE
Update predict_base.py

### DIFF
--- a/onnxocr/predict_base.py
+++ b/onnxocr/predict_base.py
@@ -7,9 +7,9 @@ class PredictBase(object):
     def get_onnx_session(self, model_dir, use_gpu):
         # 使用gpu
         if use_gpu:
-            providers = providers=['CUDAExecutionProvider']
+            providers =[('CUDAExecutionProvider',{"cudnn_conv_algo_search": "DEFAULT"}),'CPUExecutionProvider']
         else:
-            providers = providers = ['CPUExecutionProvider']
+            providers =['CPUExecutionProvider']
 
         onnx_session = onnxruntime.InferenceSession(model_dir, None,providers=providers)
 


### PR DESCRIPTION
调整providers的CUDAExecutionProvider参数,优化gpu推理速度比cpu还慢的问题,参看 https://www.zywvvd.com/notes/study/deep-learning/deploy/onnxruntime-cuda-speedup/onnxruntime-cuda-speedup/