### PR TITLE
添加一个批处理OCR页面

### DIFF
--- a/onnxocr/ocr_images_pdfs.py
+++ b/onnxocr/ocr_images_pdfs.py
@@ -1,0 +1,268 @@
+# logic.py
+import sys
+import os
+# 添加父目录到sys.path，便于导入onnxocr包
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from onnxocr.onnx_paddleocr import ONNXPaddleOcr, sav2Img
+import cv2
+from typing import List, Callable
+from pathlib import Path
+import time
+import numpy as np
+
+# 尝试导入pdf2image用于PDF转图片
+try:
+    from pdf2image import convert_from_path
+except ImportError:
+    convert_from_path = None
+
+# 尝试导入pymupdf用于PDF转图片
+try:
+    import fitz  # pymupdf
+    def pdf_to_images(pdf_path, dpi=200):
+        """
+        使用pymupdf将PDF每一页转为图片（numpy数组）
+        """
+        doc = fitz.open(pdf_path)
+        images = []
+        for page in doc:
+            pix = page.get_pixmap(dpi=dpi)
+            img = np.frombuffer(pix.samples, dtype=np.uint8)
+            img = img.reshape((pix.height, pix.width, pix.n))
+            if pix.n == 4:
+                img = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
+            images.append(img)
+        return images
+except ImportError:
+    pdf_to_images = None
+
+class OCRLogic:
+    """
+    OCR 业务逻辑主类，支持批量图片/PDF识别，多线程加速，模型热切换等
+    """
+    def __init__(self, status_callback: Callable[[str], None]):
+        """
+        初始化，传入状态回调函数用于UI进度提示
+        """
+        self.status_callback = status_callback
+        # 默认初始化OCR模型
+        self.model = ONNXPaddleOcr(use_angle_cls=True, use_gpu=False)
+
+    def run(self, files: List[str], save_txt: bool, merge_txt: bool, output_img: bool = False, file_time_callback=None, pdf_progress_callback=None, max_workers: int = 4):
+        """
+        批量图片/PDF识别主入口，支持多线程加速
+        files: 待识别文件路径列表
+        save_txt: 是否保存txt
+        merge_txt: 是否合并为一个txt
+        output_img: 是否输出带框图片
+        file_time_callback: 单文件识别耗时回调
+        pdf_progress_callback: PDF页进度回调
+        max_workers: 最大线程数，默认4
+        """
+        import concurrent.futures
+        start_time = time.time()
+        all_text = [None] * len(files)  # 用于顺序合并结果
+        def process_one(idx_file):
+            idx, file = idx_file
+            ext = os.path.splitext(file)[1].lower()
+            self.status_callback(f"正在处理: {os.path.basename(file)} ({idx+1}/{len(files)})")
+            t0 = time.time()
+            text = ""
+            if ext == ".pdf":
+                # PDF转图片后识别
+                if pdf_to_images is None:
+                    raise RuntimeError("未安装pymupdf库，无法处理PDF文件。请先安装pymupdf。")
+                images = pdf_to_images(file, dpi=300)
+                text = self._ocr_images(images, file, save_txt, merge_txt, output_img=output_img, is_pdf=True, pdf_progress_callback=pdf_progress_callback, max_workers=max_workers)
+            else:
+                # 普通图片识别，兼容中文路径
+                try:
+                    if file.lower().endswith('.bmp'):
+                        img = cv2.imdecode(np.fromfile(file, dtype=np.uint8), cv2.IMREAD_COLOR)
+                    else:
+                        with open(file, 'rb') as fimg:
+                            img_array = np.frombuffer(fimg.read(), np.uint8)
+                        img = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
+                except Exception as e:
+                    self.status_callback(f"图片读取失败: {file}，错误: {e}")
+                    if file_time_callback:
+                        file_time_callback(idx, 0)
+                    return (idx, "")
+                if img is None:
+                    self.status_callback(f"文件无法读取或不是有效图片: {file}")
+                    if file_time_callback:
+                        file_time_callback(idx, 0)
+                    return (idx, "")
+                text = self._ocr_image(img, file, save_txt, output_img=output_img)
+            t1 = time.time()
+            if file_time_callback:
+                file_time_callback(idx, t1-t0)
+            self.status_callback(f"{os.path.basename(file)} 识别用时: {t1-t0:.2f} 秒")
+            if len(files) > 1:
+                avg = (t1 - start_time) / (idx + 1)
+                self.status_callback(f"已完成 {idx+1}/{len(files)}，平均单张用时: {avg:.2f} 秒")
+            return (idx, text)
+        # 多线程处理所有文件，结果按索引回填，保证顺序
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [executor.submit(process_one, (idx, file)) for idx, file in enumerate(files)]
+            for future in concurrent.futures.as_completed(futures):
+                idx, text = future.result()
+                all_text[idx] = text
+        # 合并写入txt
+        if save_txt and merge_txt and len(files) > 1:
+            out_dir = self._get_output_dir(files[0])
+            timestamp = time.strftime("%Y%m%d_%H%M%S")
+            out_txt = os.path.join(out_dir, f"merged_ocr_{timestamp}.txt")
+            with open(out_txt, "w", encoding="utf-8") as f:
+                for text in all_text:
+                    if text:
+                        f.write(text)
+                        f.write("\n\n")
+        elapsed = time.time() - start_time
+        if files:
+            out_dir = self._get_output_dir(files[0])
+            self.status_callback(f"识别完成，总耗时：{elapsed:.2f}秒，文件保存在：{out_dir}")
+        else:
+            self.status_callback(f"识别完成，总耗时：{elapsed:.2f}秒")
+
+    def _ocr_images(self, images, pdf_path, save_txt, merge_txt, output_img=False, is_pdf=False, pdf_progress_callback=None, max_workers: int = 4):
+        """
+        PDF转图片后，批量图片识别，支持多线程加速
+        images: PDF每页图片（numpy数组）
+        pdf_path: 原PDF路径
+        save_txt: 是否保存txt
+        merge_txt: 是否合并txt（未用）
+        output_img: 是否输出带框图片
+        pdf_progress_callback: 页进度回调
+        max_workers: 最大线程数，默认4
+        """
+        import concurrent.futures
+        out_dir = self._get_output_dir(pdf_path)
+        pdf_text = [None] * len(images)
+        timestamp = time.strftime("%Y%m%d_%H%M%S")
+        total = len(images)
+        def process_page(i_img):
+            i, img = i_img
+            img_cv = cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
+            result = self.model.ocr(img_cv)
+            if output_img:
+                out_img_path = os.path.join(out_dir, f"{Path(pdf_path).stem}_page{i+1}_ocr.jpg")
+                sav2Img(img_cv, result, name=out_img_path)
+            page_text = self._result_to_text(result)
+            return (i, page_text)
+        # 多线程识别每一页，结果按页码顺序合并
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [executor.submit(process_page, (i, img)) for i, img in enumerate(images)]
+            for future in concurrent.futures.as_completed(futures):
+                i, page_text = future.result()
+                pdf_text[i] = page_text
+                if pdf_progress_callback:
+                    pdf_progress_callback(i + 1, total)
+        if save_txt:
+            txt_path = os.path.join(out_dir, f"{Path(pdf_path).stem}_ocr_{timestamp}.txt")
+            with open(txt_path, "w", encoding="utf-8") as f:
+                f.write("\n\n".join(pdf_text))
+        return "\n\n".join(pdf_text)
+
+    def _ocr_image(self, img, img_path, save_txt, output_img=False):
+        """
+        单张图片OCR识别，支持保存txt和输出带框图片
+        """
+        out_dir = self._get_output_dir(img_path)
+        result = self.model.ocr(img)
+        if output_img:
+            out_img_path = os.path.join(out_dir, f"{Path(img_path).stem}_ocr.jpg")
+            sav2Img(img, result, name=out_img_path)
+        text = self._result_to_text(result)
+        if save_txt:
+            timestamp = time.strftime("%Y%m%d_%H%M%S")
+            txt_path = os.path.join(out_dir, f"{Path(img_path).stem}_ocr_{timestamp}.txt")
+            with open(txt_path, "w", encoding="utf-8") as f:
+                f.write(text)
+        return text
+
+    def _result_to_text(self, result):
+        """
+        将OCR识别结果结构化为纯文本，兼容只检测无识别内容的情况
+        """
+        # 健壮性检查，防止result为空或结构异常
+        if not result or not isinstance(result, list) or not result[0] or not isinstance(result[0], list):
+            return "[未检测到内容]"
+        lines = []
+        for box in result[0]:
+            # 兼容只检测无识别内容的情况
+            if isinstance(box, list) and len(box) == 2 and isinstance(box[1], (list, tuple)) and len(box[1]) >= 1:
+                lines.append(str(box[1][0]))
+            elif isinstance(box, list) and (isinstance(box[0], (list, tuple)) or isinstance(box[0], float)):
+                # 只有检测框，无识别内容
+                lines.append("[未识别] " + str(box))
+            else:
+                lines.append(str(box))
+        return "\n".join(lines)
+
+    def _get_output_dir(self, file_path):
+        """
+        获取输出目录，自动创建
+        """
+        base_dir = os.path.dirname(file_path)
+        out_dir = os.path.join(base_dir, "Output_OCR")
+        os.makedirs(out_dir, exist_ok=True)
+        return out_dir
+
+    def set_model(self, model_name, use_gpu=False):
+        """
+        切换OCR模型，支持多模型热切换，所有模型统一用ppocrv5字典
+        use_gpu: 是否启用GPU
+        """
+        import os
+        import tkinter.messagebox as messagebox
+        base_model_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "onnxocr", "models"))
+        model_map = {
+            "PP-OCRv5": "ppocrv5",
+            "PP-OCRv4": "ppocrv4",
+            "ch_ppocr_server_v2.0": "ch_ppocr_server_v2.0"
+        }
+        model_dir = model_map.get(model_name, "ppocrv5")
+        model_path = os.path.join(base_model_dir, model_dir)
+        det_model_dir = os.path.join(model_path, "det", "det.onnx")
+        cls_model_dir = os.path.join(model_path, "cls", "cls.onnx")
+        rec_char_dict_path = os.path.join(base_model_dir, "ppocrv5", "ppocrv5_dict.txt")
+        rec_model_dir = os.path.join(model_path, "rec", "rec.onnx") if os.path.exists(os.path.join(model_path, "rec", "rec.onnx")) else None
+        ocr_kwargs = dict(
+            use_angle_cls=True,
+            use_gpu=use_gpu,  # 关键：传递GPU参数
+            det_model_dir=det_model_dir,
+            cls_model_dir=cls_model_dir,
+            rec_char_dict_path=rec_char_dict_path
+        )
+        if rec_model_dir and os.path.exists(rec_model_dir):
+            ocr_kwargs["rec_model_dir"] = rec_model_dir
+        try:
+            self.model = ONNXPaddleOcr(**ocr_kwargs)
+            if use_gpu:
+                try:
+                    import onnxruntime as ort
+                    providers = self.model.session.get_providers() if hasattr(self.model, 'session') else []
+                    if not any('CUDA' in p for p in providers):
+                        msg = ("未检测到可用GPU，已自动切换为CPU推理。请检查CUDA/cuDNN环境配置。")
+                        if hasattr(self, 'ui_ref') and hasattr(self.ui_ref, 'update_gpu_status'):
+                            self.ui_ref.update_gpu_status(msg)
+                        if hasattr(self, 'status_callback'):
+                            self.status_callback("[警告] 未检测到可用GPU，已切换为CPU推理。请检查CUDA/cuDNN环境配置。")
+                except Exception:
+                    msg = ("检测GPU状态时发生异常，可能未正确安装CUDA/cuDNN或onnxruntime-gpu。已自动切换为CPU推理。")
+                    if hasattr(self, 'ui_ref') and hasattr(self.ui_ref, 'update_gpu_status'):
+                        self.ui_ref.update_gpu_status(msg)
+                    if hasattr(self, 'status_callback'):
+                        self.status_callback("[警告] GPU检测异常，已切换为CPU推理。请检查CUDA/cuDNN环境配置。")
+        except Exception as e:
+            if use_gpu:
+                msg = f"GPU初始化失败，已自动切换为CPU。请检查CUDA/cuDNN环境配置。错误信息: {e}"
+                if hasattr(self, 'ui_ref') and hasattr(self.ui_ref, 'update_gpu_status'):
+                    self.ui_ref.update_gpu_status(msg)
+                if hasattr(self, 'status_callback'):
+                    self.status_callback("[警告] GPU初始化失败，已切换为CPU推理。请检查CUDA/cuDNN环境配置。")
+                ocr_kwargs["use_gpu"] = False
+                self.model = ONNXPaddleOcr(**ocr_kwargs)
+            else:
+                raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,6 @@ scikit-image
 imgaug
 lmdb
 tqdm
-numpy==1.26.4
+numpy<2.0.0
+pymupdf
+pdf2image

--- a/static/webui.css
+++ b/static/webui.css
@@ -1,0 +1,313 @@
+body {
+    font-family: 'Segoe UI', 'Microsoft YaHei', Arial, sans-serif;
+    background: linear-gradient(135deg, #e0e7ff 0%, #f8fafc 100%);
+    margin: 0;
+    min-height: 100vh;
+    width: 100vw;
+    box-sizing: border-box;
+}
+.container {
+    width: 90vw;
+    min-height: 80vh;
+    margin: 4vh auto 0 auto;
+    background: #fff;
+    border-radius: 22px;
+    box-shadow: 0 10px 40px #7b8cff22, 0 1.5px 8px #0001;
+    padding: 56px 0 40px 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    max-width: 1100px;
+    transition: box-shadow 0.3s;
+}
+h2 {
+    text-align: center;
+    margin-bottom: 36px;
+    font-size: 2.5rem;
+    color: #2d3a4a;
+    letter-spacing: 2px;
+    font-weight: 700;
+    text-shadow: 0 2px 8px #7b8cff22;
+}
+.form-row {
+    margin-bottom: 22px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+}
+.form-row label {
+    margin-right: 12px;
+    font-weight: 500;
+    color: #3b4252;
+}
+#fileInput {
+    display: none;
+}
+.drop-zone {
+    border: 2.5px dashed #7b8cff;
+    border-radius: 14px;
+    padding: 48px 0;
+    text-align: center;
+    color: #5a5a5a;
+    background: #f4f7ff;
+    cursor: pointer;
+    margin-bottom: 20px;
+    font-size: 1.15rem;
+    transition: background 0.2s, border-color 0.2s;
+    width: 96%;
+    min-width: 320px;
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 120px;
+    box-sizing: border-box;
+    box-shadow: 0 2px 12px #7b8cff11;
+}
+.drop-zone.dragover {
+    background: #e0eaff;
+    border-color: #3b82f6;
+}
+#resultArea {
+    margin-top: 32px;
+    width: 90%;
+    max-width: 900px;
+}
+.download-row {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 8px;
+    width: 90%;
+    max-width: 900px;
+}
+.result-block, #previewArea {
+    display: flex;
+    align-items: flex-start;
+    gap: 18px;
+}
+.ocr-image-preview {
+    max-width: 320px;
+    max-height: 220px;
+    border-radius: 8px;
+    box-shadow: 0 1px 8px #0002;
+    background: #fff;
+    margin-right: 8px;
+}
+.ocr-text-content {
+    flex: 1;
+    min-width: 0;
+    max-height: 220px;
+    overflow-y: auto;
+    background: #f7faff;
+    border-radius: 8px;
+    padding: 12px 16px;
+    box-sizing: border-box;
+    box-shadow: 0 1px 4px #0001;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+}
+.copy-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 2px;
+    margin-left: 8px;
+    border-radius: 4px;
+    transition: background 0.2s;
+    display: flex;
+    align-items: center;
+}
+.copy-btn:hover {
+    background: #e0eaff;
+}
+.copy-btn svg {
+    display: block;
+}
+.result-block {
+    background: #f7faff;
+    border-radius: 8px;
+    padding: 0;
+    margin-bottom: 14px;
+    border-left: 4px solid #7b8cff;
+    box-shadow: 0 1px 4px #0001;
+}
+.ocr-text-content pre {
+    white-space: pre-wrap;
+    word-break: break-all;
+    font-size: 1.01rem;
+    color: #2d3a4a;
+    margin: 0;
+}
+#downloadBtn {
+    margin-top: 22px;
+    display: none;
+    background: linear-gradient(90deg, #7b8cff 0%, #3b82f6 100%);
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    padding: 10px 28px;
+    font-size: 1.08rem;
+    cursor: pointer;
+    box-shadow: 0 2px 8px #7b8cff22;
+    transition: background 0.2s;
+}
+#downloadBtn:hover {
+    background: linear-gradient(90deg, #3b82f6 0%, #7b8cff 100%);
+}
+#loading {
+    display: none;
+    text-align: center;
+    margin-top: 20px;
+    color: #3b82f6;
+    font-size: 1.1rem;
+}
+#fileList {
+    margin: 0;
+    padding: 0 0 0 20px;
+    color: #444;
+    font-size: 15px;
+    min-height: 24px;
+}
+#clearBtn {
+    margin-left: 18px;
+    background: #f3f4f6;
+    color: #3b4252;
+    border: 1.5px solid #d1d5db;
+    border-radius: 6px;
+    padding: 7px 18px;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background 0.2s, border-color 0.2s;
+}
+#clearBtn:hover {
+    background: #e0eaff;
+    border-color: #7b8cff;
+}
+button[type="submit"] {
+    background: linear-gradient(90deg, #7b8cff 0%, #3b82f6 100%);
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    padding: 10px 32px;
+    font-size: 1.08rem;
+    cursor: pointer;
+    box-shadow: 0 2px 8px #7b8cff22;
+    transition: background 0.2s;
+    display: block;
+    margin: 0 auto;
+}
+button[type="submit"]:hover {
+    background: linear-gradient(90deg, #3b82f6 0%, #7b8cff 100%);
+}
+select {
+    border-radius: 6px;
+    border: 1.5px solid #d1d5db;
+    padding: 7px 16px;
+    font-size: 1rem;
+    background: #f9fafb;
+    color: #2d3a4a;
+    outline: none;
+    transition: border-color 0.2s;
+}
+select:focus {
+    border-color: #7b8cff;
+}
+#progressArea {
+    width: 80%;
+    margin: 32px 0 0 0;
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+}
+.progress-bar-bg {
+    width: 80%;
+    height: 16px;
+    background: #e0eaff;
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 4px;
+}
+.progress-bar {
+    height: 100%;
+    background: linear-gradient(90deg, #7b8cff 0%, #3b82f6 100%);
+    border-radius: 8px;
+    width: 0%;
+    transition: width 0.3s;
+}
+#progressText {
+    color: #3b4252;
+    font-size: 1rem;
+    margin-bottom: 2px;
+}
+#elapsedTime {
+    color: #888;
+    font-size: 0.98rem;
+    margin-top: 2px;
+}
+@media (max-width: 900px) {
+    .container {
+        width: 98vw;
+        min-height: 90vh;
+        padding: 18px 0 18px 0;
+        border-radius: 0;
+        box-shadow: none;
+    }
+    .drop-zone {
+        width: 96vw;
+        min-width: 0;
+        max-width: 100vw;
+    }
+}
+@media (max-width: 600px) {
+    .container {
+        width: 100vw;
+        min-height: 100vh;
+        padding: 0;
+        border-radius: 0;
+        box-shadow: none;
+    }
+    h2 {
+        font-size: 1.3rem;
+    }
+    .form-row {
+        flex-direction: column;
+        align-items: stretch;
+        width: 100%;
+    }
+    .form-row label {
+        margin-bottom: 6px;
+    }
+    .drop-zone {
+        width: 98vw;
+        min-width: 0;
+        max-width: 100vw;
+        padding: 28px 0;
+        min-height: 60px;
+        font-size: 1rem;
+    }
+    #downloadBtn, button[type="submit"] {
+        width: 100%;
+        margin-left: 0;
+        margin-top: 10px;
+    }
+    #clearBtn {
+        width: 100%;
+        min-width: 0;
+        max-width: 100vw;
+        font-size: 0.98rem;
+        padding: 7px 10px;
+        margin-top: 10px;
+        margin-left: 0;
+        align-self: stretch;
+    }
+    #resultArea, .download-row {
+        width: 98vw;
+        max-width: 100vw;
+    }
+}

--- a/templates/webui.html
+++ b/templates/webui.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8" />
+    <title>OnnxOCR Web UI</title>
+    <link rel="stylesheet" href="/static/webui.css">
+</head>
+<body>
+<div class="container">
+    <h2>OnnxOCR Web UI</h2>
+    <form id="ocrForm">
+        <div class="form-row" style="justify-content: flex-start;">
+            <label for="modelSelect">选择模型：</label>
+            <select id="modelSelect" name="model_name">
+                <option value="PP-OCRv5">PP-OCRv5</option>
+                <option value="PP-OCRv4">PP-OCRv4</option>
+                <option value="ch_ppocr_server_v2.0">ch_ppocr_server_v2.0</option>
+            </select>
+            <button type="button" id="clearBtn">清除</button>
+        </div>
+        <div class="form-row">
+            <div id="dropZone" class="drop-zone">点击或拖拽图片/PDF文件到此处（可多选）</div>
+            <input id="fileInput" type="file" name="files" multiple accept="image/*,.pdf" />
+        </div>
+        <div class="form-row">
+            <ul id="fileList"></ul>
+        </div>
+        <div class="form-row button-row">
+            <button type="submit">开始识别</button>
+        </div>
+    </form>
+    <div id="previewArea"></div>
+    <div id="progressArea">
+        <div id="progressText"></div>
+        <div class="progress-bar-bg"><div class="progress-bar" id="progressBar"></div></div>
+        <div id="elapsedTime"></div>
+    </div>
+    <div class="download-row">
+        <button id="downloadBtn">下载全部TXT（压缩包）</button>
+    </div>
+    <div id="loading">正在识别，请稍候...</div>
+    <div id="resultArea"></div>
+</div>
+<div id="globalTip" style="display:none;position:fixed;top:32px;right:32px;z-index:9999;min-width:120px;padding:12px 28px;background:#7b8cff;color:#fff;border-radius:8px;box-shadow:0 2px 8px #7b8cff22;font-size:1.08rem;transition:opacity 0.3s;opacity:0;"></div>
+<script>
+const dropZone = document.getElementById('dropZone');
+const fileInput = document.getElementById('fileInput');
+const ocrForm = document.getElementById('ocrForm');
+const resultArea = document.getElementById('resultArea');
+const downloadBtn = document.getElementById('downloadBtn');
+const loading = document.getElementById('loading');
+const fileList = document.getElementById('fileList');
+const clearBtn = document.getElementById('clearBtn');
+const progressArea = document.getElementById('progressArea');
+const progressBar = document.getElementById('progressBar');
+const progressText = document.getElementById('progressText');
+const elapsedTime = document.getElementById('elapsedTime');
+let lastZipUrl = null;
+
+function updateFileList() {
+    fileList.innerHTML = '';
+    if (fileInput.files.length === 0) {
+        fileList.innerHTML = '<li style="color:#888;">未选择文件</li>';
+        return;
+    }
+    for (const file of fileInput.files) {
+        const li = document.createElement('li');
+        li.textContent = file.name;
+        fileList.appendChild(li);
+    }
+}
+
+// 拖拽上传
+['dragenter','dragover'].forEach(evt => dropZone.addEventListener(evt, e => {
+    e.preventDefault();
+    dropZone.classList.add('dragover');
+}));
+['dragleave','drop'].forEach(evt => dropZone.addEventListener(evt, e => {
+    e.preventDefault();
+    dropZone.classList.remove('dragover');
+}));
+dropZone.addEventListener('click', () => fileInput.click());
+dropZone.addEventListener('drop', e => {
+    fileInput.files = e.dataTransfer.files;
+    updateFileList();
+});
+fileInput.addEventListener('change', updateFileList);
+
+ocrForm.addEventListener('submit', async function(e) {
+    e.preventDefault();
+    if (!fileInput.files.length) {
+        alert('请先选择图片或PDF文件');
+        return;
+    }
+    loading.style.display = 'none'; // 立即隐藏 loading
+    resultArea.innerHTML = '';
+    downloadBtn.style.display = 'none';
+    fileList.innerHTML = '';
+    progressArea.style.display = 'flex';
+    progressBar.style.width = '0%';
+    progressText.textContent = '正在准备识别...';
+    elapsedTime.textContent = '';
+    const startTime = Date.now();
+    const formData = new FormData();
+    for (const file of fileInput.files) {
+        formData.append('files', file);
+    }
+    formData.append('model_name', document.getElementById('modelSelect').value);
+    // 保存所有图片文件的base名和File对象
+    const imageFileMap = {};
+    for (const file of fileInput.files) {
+        if (file.type.startsWith('image/')) {
+            const base = file.name.replace(/\.[^.]+$/, '');
+            imageFileMap[base] = file;
+        }
+    }
+    try {
+        let fakeProgress = 0;
+        const fakeTimer = setInterval(() => {
+            if (fakeProgress < 80) {
+                fakeProgress += Math.random() * 8 + 2;
+                progressBar.style.width = Math.min(fakeProgress, 80) + '%';
+                progressText.textContent = '正在识别文件...';
+            }
+        }, 300);
+        const resp = await fetch('/ocr', { method: 'POST', body: formData });
+        clearInterval(fakeTimer);
+        progressBar.style.width = '100%';
+        progressText.textContent = '识别完成';
+        const data = await resp.json();
+        if (!data.success) {
+            progressArea.style.display = 'none';
+            resultArea.innerHTML = `<div style='color:red;'>识别失败：${data.msg || ''}</div>`;
+            lastZipUrl = null;
+            return;
+        }
+        // 多图片多结果展示
+        previewArea.innerHTML = '';
+        resultArea.innerHTML = '';
+        // 构建图片base名到File对象的映射
+        const imgMap = {};
+        for (const file of fileInput.files) {
+            if (file.type.startsWith('image/')) {
+                const base = file.name.replace(/\.[^.]+$/, '');
+                imgMap[base] = file;
+            }
+        }
+        data.results.forEach(r => {
+            const txtBase = r.filename.replace(/\.txt$/, '');
+            const div = document.createElement('div');
+            div.className = 'result-block';
+            let imgHtml = '';
+            if (imgMap[txtBase]) {
+                const url = URL.createObjectURL(imgMap[txtBase]);
+                imgHtml = `<img class=\"ocr-image-preview\" src=\"${url}\" alt=\"${r.filename}\">`;
+            }
+            // 新增复制按钮
+            const copyBtnHtml = `<button class=\"copy-btn\" title=\"复制文本\"><svg width=\"18\" height=\"18\" viewBox=\"0 0 20 20\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><rect x=\"5\" y=\"5\" width=\"10\" height=\"12\" rx=\"2\" fill=\"#7b8cff\"/><rect x=\"3\" y=\"3\" width=\"10\" height=\"12\" rx=\"2\" stroke=\"#7b8cff\" stroke-width=\"1.5\" fill=\"none\"/></svg></button>`;
+            div.innerHTML = `${imgHtml}<div class=\"ocr-text-content\"><div style=\"display:flex;justify-content:space-between;align-items:flex-start;\"><b>${r.filename}</b>${copyBtnHtml}</div><pre>${r.content}</pre></div>`;
+            resultArea.appendChild(div);
+        });
+        // 事件委托绑定复制按钮点击事件
+        resultArea.addEventListener('click', function(e) {
+            if (e.target.closest('.copy-btn')) {
+                const btn = e.target.closest('.copy-btn');
+                const pre = btn.closest('.ocr-text-content').querySelector('pre');
+                if (pre) {
+                    navigator.clipboard.writeText(pre.textContent).then(() => {
+                        showTip('复制成功');
+                    }).catch(() => {
+                        showTip('复制失败，请手动复制', '#f87171');
+                    });
+                }
+            }
+        });
+        const used = ((Date.now() - startTime) / 1000).toFixed(2);
+        elapsedTime.textContent = `识别总耗时：${used} 秒`;
+        downloadBtn.style.display = 'inline-block';
+        lastZipUrl = data.zip_url || null;
+    } catch (err) {
+        progressArea.style.display = 'none';
+        resultArea.innerHTML = `<div style='color:red;'>请求失败：${err}</div>`;
+    }
+});
+
+downloadBtn.addEventListener('click', function() {
+    if (lastZipUrl) {
+        // 采用 a 标签下载，兼容所有浏览器
+        const a = document.createElement('a');
+        a.href = lastZipUrl;
+        a.download = '';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+    } else {
+        alert('未找到可下载的压缩包');
+    }
+});
+
+clearBtn.addEventListener('click', function() {
+    fileInput.value = '';
+    updateFileList();
+    resultArea.innerHTML = '';
+    downloadBtn.style.display = 'none';
+    previewArea.innerHTML = '';
+    progressArea.style.display = 'none';
+    progressBar.style.width = '0%';
+    progressText.textContent = '';
+    elapsedTime.textContent = '';
+});
+
+function showTip(msg, color = '#7b8cff') {
+    const tip = document.getElementById('globalTip');
+    tip.textContent = msg;
+    tip.style.background = color;
+    tip.style.display = 'block';
+    tip.style.opacity = '1';
+    clearTimeout(tip._timer);
+    tip._timer = setTimeout(() => {
+        tip.style.opacity = '0';
+        setTimeout(() => { tip.style.display = 'none'; }, 400);
+    }, 1500);
+}
+
+// 复制按钮事件绑定
+setTimeout(() => {
+    document.querySelectorAll('.copy-btn').forEach(btn => {
+        btn.onclick = function(e) {
+            const pre = btn.closest('.ocr-text-content').querySelector('pre');
+            if (pre) {
+                navigator.clipboard.writeText(pre.textContent).then(() => {
+                    btn.title = '已复制!';
+                    btn.style.background = '#e0eaff';
+                    setTimeout(() => {
+                        btn.title = '复制文本';
+                        btn.style.background = '';
+                    }, 1200);
+                });
+            }
+        };
+    });
+}, 100);
+</script>
+</body>
+</html>

--- a/webui.py
+++ b/webui.py
@@ -1,0 +1,135 @@
+import os
+import time
+import zipfile
+from flask import Flask, render_template, request, jsonify, send_file, redirect, url_for
+from werkzeug.utils import secure_filename
+from onnxocr.ocr_images_pdfs import OCRLogic
+import cv2
+import base64
+import numpy as np
+from onnxocr.onnx_paddleocr import ONNXPaddleOcr
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+UPLOAD_ROOT = os.path.join(BASE_DIR, "uploads")
+RESULT_ROOT = os.path.join(BASE_DIR, "results")
+os.makedirs(UPLOAD_ROOT, exist_ok=True)
+os.makedirs(RESULT_ROOT, exist_ok=True)
+
+MODEL_OPTIONS = ["PP-OCRv5", "PP-OCRv4", "ch_ppocr_server_v2.0"]
+
+app = Flask(__name__, static_folder="static", template_folder="templates")
+app.config['MAX_CONTENT_LENGTH'] = 200 * 1024 * 1024  # 200MB
+
+ocr_logic = OCRLogic(lambda msg: print(msg))
+# 独立 OCR 模型实例，避免影响 ocr_logic
+ocr_model_api = ONNXPaddleOcr(use_angle_cls=True, use_gpu=False)
+
+@app.route("/")
+def index():
+    return render_template("webui.html", model_options=MODEL_OPTIONS)
+
+@app.errorhandler(404)
+def not_found(e):
+    path = request.path
+    if not path.startswith("/static") and not path.startswith("/download"):
+        return redirect(url_for("index"))
+    return jsonify({"detail": "NotFound"}), 404
+
+@app.route("/set_model", methods=["POST"])
+def set_model():
+    model_name = request.form.get("model_name")
+    try:
+        ocr_logic.set_model(model_name)
+        return {"success": True, "msg": f"模型已切换为 {model_name}"}
+    except Exception as e:
+        return {"success": False, "msg": str(e)}
+
+@app.route("/ocr", methods=["POST"])
+def ocr_files():
+    files = request.files.getlist("files")
+    model_name = request.form.get("model_name")
+    if not files or not model_name:
+        return jsonify({"success": False, "msg": "缺少文件或模型参数"}), 400
+    try:
+        ocr_logic.set_model(model_name)
+    except Exception as e:
+        return jsonify({"success": False, "msg": f"模型切换失败: {e}"}), 500
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    session_dir = os.path.join(RESULT_ROOT, timestamp)
+    os.makedirs(session_dir, exist_ok=True)
+    file_paths = []
+    for file in files:
+        filename = secure_filename(file.filename)
+        file_path = os.path.join(session_dir, filename)
+        file.save(file_path)
+        file_paths.append(file_path)
+    results = []
+    def status_callback(msg): pass
+    logic = OCRLogic(status_callback)
+    logic.set_model(model_name)
+    logic.run(file_paths, save_txt=True, merge_txt=False, output_img=False)
+    txt_files = []
+    for file_path in file_paths:
+        out_dir = os.path.join(os.path.dirname(file_path), "Output_OCR")
+        if not os.path.exists(out_dir):
+            continue
+        for fname in os.listdir(out_dir):
+            if fname.endswith(".txt") and fname.startswith(os.path.splitext(os.path.basename(file_path))[0]):
+                txt_files.append(os.path.join(out_dir, fname))
+                with open(os.path.join(out_dir, fname), "r", encoding="utf-8") as f:
+                    content = f.read()
+                results.append({"filename": fname, "content": content})
+    zip_path = os.path.join(session_dir, f"ocr_txt_{timestamp}.zip")
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        for txt_file in txt_files:
+            zipf.write(txt_file, os.path.basename(txt_file))
+    return jsonify({
+        "success": True,
+        "results": results,
+        "zip_url": f"/download/{timestamp}"
+    })
+
+@app.route("/download/<timestamp>")
+def download_zip(timestamp):
+    session_dir = os.path.join(RESULT_ROOT, timestamp)
+    zip_path = os.path.join(session_dir, f"ocr_txt_{timestamp}.zip")
+    if os.path.exists(zip_path):
+        return send_file(zip_path, as_attachment=True, download_name=f"ocr_txt_{timestamp}.zip")
+    return jsonify({"success": False, "msg": "文件不存在"}), 404
+
+@app.route("/ocr_api", methods=["POST"])
+def ocr_api():
+    data = request.get_json()
+    if not data or "image" not in data:
+        return jsonify({"error": "Invalid request, 'image' field is required."}), 400
+    image_base64 = data["image"]
+    try:
+        image_bytes = base64.b64decode(image_base64)
+        image_np = np.frombuffer(image_bytes, dtype=np.uint8)
+        img = cv2.imdecode(image_np, cv2.IMREAD_COLOR)
+        if img is None:
+            return jsonify({"error": "Failed to decode image from base64."}), 400
+    except Exception as e:
+        return jsonify({"error": f"Image decoding failed: {str(e)}"}), 400
+    start_time = time.time()
+    result = ocr_model_api.ocr(img)
+    end_time = time.time()
+    processing_time = end_time - start_time
+    ocr_results = []
+    for line in result[0]:
+        if isinstance(line[0], (list, np.ndarray)):
+            bounding_box = np.array(line[0]).reshape(4, 2).tolist()
+        else:
+            bounding_box = []
+        ocr_results.append({
+            "text": line[1][0],
+            "confidence": float(line[1][1]),
+            "bounding_box": bounding_box
+        })
+    return jsonify({
+        "processing_time": processing_time,
+        "results": ocr_results
+    })
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5005, debug=True)


### PR DESCRIPTION
1. 新增webui.py、webui.html、ocr_images_pdfs.py3个文件，使用Flask实现简单批量OCR处理一个或多个图片或PDF文件。
2. 建议使用Python 3.8以上版本，处理速度提升很多，使用cp312时，发现需要对onnxruntime-gpu取消版本限制、numpy<2.0.0做出版本限制。
3. 支持多线程OCR图片。

![1750323296737_d](https://github.com/user-attachments/assets/e16dce72-3cd9-40c0-aeb0-7aedbbf635b7)

![1750323276956_d](https://github.com/user-attachments/assets/29f1b4be-01d1-4521-ae1d-5d9791d2bd59)

