### PR TITLE
refactor: 统一日志系统，基于 loguru 重构

### DIFF
--- a/onnxocr/inference_engine.py
+++ b/onnxocr/inference_engine.py
@@ -4,6 +4,10 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import onnxruntime
 
+from .logger import get_logger
+
+log = get_logger("inference_engine")
+
 
 Provider = Union[str, Tuple[str, Dict[str, Any]]]
 
@@ -136,8 +140,13 @@ def create_session(
         gpu_id=gpu_id,
         providers=providers,
     )
-    return InferenceSession(
-        model_path,
-        sess_options=sess_options,
-        providers=session_providers,
-    )
+    log.info("创建 ONNX session: {}, providers={}", model_path, session_providers)
+    try:
+        return InferenceSession(
+            model_path,
+            sess_options=sess_options,
+            providers=session_providers,
+        )
+    except Exception as e:
+        log.error("模型加载失败: {}, 错误: {}", model_path, e)
+        raise

--- a/onnxocr/inference_engine.py
+++ b/onnxocr/inference_engine.py
@@ -1,3 +1,4 @@
+import os
 import platform
 from enum import Enum
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
@@ -135,6 +136,11 @@ def create_session(
     gpu_id: int = 0,
     sess_options: Optional[SessionOptions] = None,
 ) -> InferenceSession:
+    if not os.path.exists(model_path):
+        raise FileNotFoundError(
+            f"Model file not found: {model_path}. "
+            f"Please download models first: python scripts/download_models.py"
+        )
     session_providers = build_providers(
         use_gpu=use_gpu,
         gpu_id=gpu_id,

--- a/onnxocr/inference_engine.py
+++ b/onnxocr/inference_engine.py
@@ -140,7 +140,7 @@ def create_session(
         gpu_id=gpu_id,
         providers=providers,
     )
-    log.info("创建 ONNX session: {}, providers={}", model_path, session_providers)
+    log.info("Creating ONNX session: {}, providers={}", model_path, session_providers)
     try:
         return InferenceSession(
             model_path,
@@ -148,5 +148,5 @@ def create_session(
             providers=session_providers,
         )
     except Exception as e:
-        log.error("模型加载失败: {}, 错误: {}", model_path, e)
+        log.error("Failed to load model: {}, error: {}", model_path, e)
         raise

--- a/onnxocr/layout_markdown.py
+++ b/onnxocr/layout_markdown.py
@@ -1,10 +1,14 @@
-﻿import os
+import os
 import time
 from pathlib import Path
 from typing import Dict, List, Optional
 
 import cv2
 import numpy as np
+
+from .logger import get_logger
+
+log = get_logger("layout_markdown")
 
 
 IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
@@ -63,6 +67,7 @@ class LayoutMarkdownConverter:
             table_model_type=table_model_type,
             table_engine_cfg=table_engine_cfg or {},
         )
+        log.info("LayoutMarkdownConverter 初始化完成, layout_model={}, table_enable={}", layout_model_type, table_enable)
 
     def convert_file(
         self,
@@ -194,6 +199,8 @@ class LayoutMarkdownConverter:
             save_path.write_bytes(data)
 
         output_path.write_text(result.markdown, encoding="utf-8")
+        elapsed = time.time() - start
+        log.info("文档转换完成: {} -> {}, 耗时: {:.2f}s", input_path, output_md_path, elapsed)
         return {
             "markdown": result.markdown,
             "markdown_path": str(output_path),

--- a/onnxocr/layout_markdown.py
+++ b/onnxocr/layout_markdown.py
@@ -67,7 +67,7 @@ class LayoutMarkdownConverter:
             table_model_type=table_model_type,
             table_engine_cfg=table_engine_cfg or {},
         )
-        log.info("LayoutMarkdownConverter 初始化完成, layout_model={}, table_enable={}", layout_model_type, table_enable)
+        log.info("LayoutMarkdownConverter initialized, layout_model={}, table_enable={}", layout_model_type, table_enable)
 
     def convert_file(
         self,
@@ -200,7 +200,7 @@ class LayoutMarkdownConverter:
 
         output_path.write_text(result.markdown, encoding="utf-8")
         elapsed = time.time() - start
-        log.info("文档转换完成: {} -> {}, 耗时: {:.2f}s", input_path, output_md_path, elapsed)
+        log.info("Document converted: {} -> {}, time: {:.2f}s", input_path, output_md_path, elapsed)
         return {
             "markdown": result.markdown,
             "markdown_path": str(output_path),

--- a/onnxocr/layout_recognition.py
+++ b/onnxocr/layout_recognition.py
@@ -3,7 +3,10 @@ from typing import Dict, Optional
 
 import numpy as np
 
+from .logger import get_logger
 from .rapid_layout import EngineType, ModelType, RapidLayout, RapidLayoutInput
+
+log = get_logger("layout_recognition")
 
 
 LAYOUT_MODEL_PATHS = {
@@ -43,6 +46,7 @@ class LayoutRecognizer:
         self.model_type = model_type
         self.model_path = model_path
         self.layout_engine = RapidLayout(cfg=cfg)
+        log.info("版面分析模型加载完成: type={}, path={}", model_type, model_path)
 
     def recognize(self, img: np.ndarray) -> Dict:
         if img is None or not isinstance(img, np.ndarray):

--- a/onnxocr/layout_recognition.py
+++ b/onnxocr/layout_recognition.py
@@ -46,7 +46,7 @@ class LayoutRecognizer:
         self.model_type = model_type
         self.model_path = model_path
         self.layout_engine = RapidLayout(cfg=cfg)
-        log.info("版面分析模型加载完成: type={}, path={}", model_type, model_path)
+        log.info("Layout model loaded: type={}, path={}", model_type, model_path)
 
     def recognize(self, img: np.ndarray) -> Dict:
         if img is None or not isinstance(img, np.ndarray):

--- a/onnxocr/license_plate.py
+++ b/onnxocr/license_plate.py
@@ -7,6 +7,9 @@ import cv2
 import numpy as np
 
 from .inference_engine import create_session
+from .logger import get_logger
+
+log = get_logger("license_plate")
 
 PLATE_CHARS = (
     "#京沪津渝冀晋蒙辽吉黑苏浙皖闽赣鲁豫鄂湘粤桂琼川贵云藏陕甘青宁新"
@@ -39,6 +42,7 @@ class LicensePlateRecognizer:
         self.session_rec = create_session(
             self.rec_model_path, providers=self.providers
         )
+        log.info("车牌识别模型加载完成: detect={}, rec={}", self.detect_model_path, self.rec_model_path)
 
     def recognize(
         self,

--- a/onnxocr/license_plate.py
+++ b/onnxocr/license_plate.py
@@ -42,7 +42,7 @@ class LicensePlateRecognizer:
         self.session_rec = create_session(
             self.rec_model_path, providers=self.providers
         )
-        log.info("车牌识别模型加载完成: detect={}, rec={}", self.detect_model_path, self.rec_model_path)
+        log.info("License plate model loaded: detect={}, rec={}", self.detect_model_path, self.rec_model_path)
 
     def recognize(
         self,

--- a/onnxocr/logger.py
+++ b/onnxocr/logger.py
@@ -1,45 +1,87 @@
+"""OnnxOCR 统一日志模块，基于 loguru。
+
+用法:
+    from onnxocr.logger import get_logger
+    log = get_logger("predict_det")
+    log.info("检测模型加载完成")
+"""
+
+import sys
 import logging
 
-LogName = 'Umi-OCR_log'
-LogFileName = 'Umi-OCR_debug.log'
+from loguru import logger
+
+# 移除 loguru 默认 handler，避免重复输出
+logger.remove()
+
+# 默认控制台输出格式
+_DEFAULT_FORMAT = (
+    "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
+    "<level>{level: <8}</level> | "
+    "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> | "
+    "<level>{message}</level>"
+)
+
+# 添加默认控制台 handler
+logger.add(
+    sys.stderr,
+    format=_DEFAULT_FORMAT,
+    level="INFO",
+    colorize=True,
+)
 
 
-class Logger:
+class InterceptHandler(logging.Handler):
+    """将标准库 logging 的日志桥接到 loguru。"""
 
-    def __init__(self):
-        self.initLogger()
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            level = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
 
-    def initLogger(self):
-        '''初始化日志'''
+        frame, depth = logging.currentframe(), 2
+        while frame and frame.f_code.co_filename == logging.__file__:
+            frame = frame.f_back
+            depth += 1
 
-        # 日志
-        self.logger = logging.getLogger(LogName)
-        self.logger.setLevel(logging.DEBUG)
-
-        # 控制台
-        streamHandler = logging.StreamHandler()
-        streamHandler.setLevel(logging.DEBUG)
-        formatPrint = logging.Formatter(
-            '【%(levelname)s】 %(message)s')
-        streamHandler.setFormatter(formatPrint)
-        # self.logger.addHandler(streamHandler)
-
-        return
-        # 日志文件
-        fileHandler = logging.FileHandler(LogFileName)
-        fileHandler.setLevel(logging.ERROR)
-        formatFile = logging.Formatter(
-            '''
-【%(levelname)s】 %(asctime)s
-%(message)s
-    文件：%(module)s | 函数：%(funcName)s | 行号：%(lineno)d
-    线程id：%(thread)d | 线程名：%(thread)s''')
-        fileHandler.setFormatter(formatFile)
-        self.logger.addHandler(fileHandler)
+        logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
 
 
-LOG = Logger()
+# 拦截标准库 logging 的根 logger
+logging.basicConfig(handlers=[InterceptHandler()], level=logging.WARNING, force=True)
+
+# 桥接 rapid_layout / rapid_table 的独立 logger
+for _name in ("RapidLayout", "RapidTable"):
+    _logging_logger = logging.getLogger(_name)
+    _logging_logger.handlers = [InterceptHandler()]
+    _logging_logger.propagate = False
 
 
-def GetLog():
-    return LOG.logger
+def get_logger(name: str = "OnnxOCR"):
+    """获取带模块标识的 logger。
+
+    Args:
+        name: 模块标识，用于区分日志来源，如 "predict_det"、"ocr" 等。
+
+    Returns:
+        loguru.Logger: 绑定了模块名称的 logger 实例。
+    """
+    return logger.bind(name=name)
+
+
+def add_file_sink(path: str, level: str = "DEBUG", rotation: str = "10 MB"):
+    """添加文件日志输出。
+
+    Args:
+        path: 日志文件路径。
+        level: 文件日志级别，默认 DEBUG。
+        rotation: 日志轮转大小，默认 10 MB。
+    """
+    logger.add(
+        path,
+        format=_DEFAULT_FORMAT,
+        level=level,
+        rotation=rotation,
+        encoding="utf-8",
+    )

--- a/onnxocr/ocr_images_pdfs.py
+++ b/onnxocr/ocr_images_pdfs.py
@@ -10,6 +10,10 @@ from pathlib import Path
 import time
 import numpy as np
 
+from .logger import get_logger
+
+log = get_logger("ocr_images_pdfs")
+
 # 尝试导入pdf2image用于PDF转图片
 try:
     from pdf2image import convert_from_path
@@ -46,6 +50,7 @@ class OCRLogic:
         """
         self.status_callback = status_callback
         # 默认初始化OCR模型
+        log.info("初始化 OCRLogic，加载默认模型")
         self.model = ONNXPaddleOcr(use_angle_cls=True, use_gpu=False)
 
     def run(self, files: List[str], save_txt: bool, merge_txt: bool, output_img: bool = False, file_time_callback=None, pdf_progress_callback=None, max_workers: int = 4):
@@ -85,11 +90,13 @@ class OCRLogic:
                         img = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
                 except Exception as e:
                     self.status_callback(f"图片读取失败: {file}，错误: {e}")
+                    log.error("图片读取失败: {}, 错误: {}", file, e)
                     if file_time_callback:
                         file_time_callback(idx, 0)
                     return (idx, "")
                 if img is None:
                     self.status_callback(f"文件无法读取或不是有效图片: {file}")
+                    log.warning("文件无法读取或不是有效图片: {}", file)
                     if file_time_callback:
                         file_time_callback(idx, 0)
                     return (idx, "")
@@ -119,6 +126,7 @@ class OCRLogic:
                         f.write(text)
                         f.write("\n\n")
         elapsed = time.time() - start_time
+        log.info("批量识别完成，共 {} 个文件，总耗时: {:.2f}秒", len(files), elapsed)
         if files:
             out_dir = self._get_output_dir(files[0])
             self.status_callback(f"识别完成，总耗时：{elapsed:.2f}秒，文件保存在：{out_dir}")
@@ -239,6 +247,7 @@ class OCRLogic:
             ocr_kwargs["rec_model_dir"] = rec_model_dir
         try:
             self.model = ONNXPaddleOcr(**ocr_kwargs)
+            log.info("模型切换成功: {}", model_name)
             if use_gpu:
                 try:
                     providers = self.model.session.get_providers() if hasattr(self.model, 'session') else []
@@ -255,6 +264,7 @@ class OCRLogic:
                     if hasattr(self, 'status_callback'):
                         self.status_callback("[警告] GPU检测异常，已切换为CPU推理。请检查CUDA/cuDNN环境配置。")
         except Exception as e:
+            log.error("模型切换失败: {}, 错误: {}", model_name, e)
             if use_gpu:
                 msg = f"GPU初始化失败，已自动切换为CPU。请检查CUDA/cuDNN环境配置。错误信息: {e}"
                 if hasattr(self, 'ui_ref') and hasattr(self.ui_ref, 'update_gpu_status'):

--- a/onnxocr/ocr_images_pdfs.py
+++ b/onnxocr/ocr_images_pdfs.py
@@ -219,7 +219,6 @@ class OCRLogic:
             use_gpu: Whether to enable GPU inference.
         """
         import os
-        import tkinter.messagebox as messagebox
         base_model_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "onnxocr", "models"))
         model_map = {
             "PP-OCRv5": "ppocrv5",

--- a/onnxocr/ocr_images_pdfs.py
+++ b/onnxocr/ocr_images_pdfs.py
@@ -1,7 +1,7 @@
 # logic.py
 import sys
 import os
-# 添加父目录到sys.path，便于导入onnxocr包
+# Add parent directory to sys.path for onnxocr package import
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from onnxocr.onnx_paddleocr import ONNXPaddleOcr, sav2Img
 import cv2
@@ -14,19 +14,17 @@ from .logger import get_logger
 
 log = get_logger("ocr_images_pdfs")
 
-# 尝试导入pdf2image用于PDF转图片
+# Try to import pdf2image for PDF-to-image conversion
 try:
     from pdf2image import convert_from_path
 except ImportError:
     convert_from_path = None
 
-# 尝试导入pymupdf用于PDF转图片
+# Try to import pymupdf for PDF-to-image conversion
 try:
     import fitz  # pymupdf
     def pdf_to_images(pdf_path, dpi=200):
-        """
-        使用pymupdf将PDF每一页转为图片（numpy数组）
-        """
+        """Convert each PDF page to a numpy image array using pymupdf."""
         doc = fitz.open(pdf_path)
         images = []
         for page in doc:
@@ -42,45 +40,45 @@ except ImportError:
 
 class OCRLogic:
     """
-    OCR 业务逻辑主类，支持批量图片/PDF识别，多线程加速，模型热切换等
+    OCR business logic: batch image/PDF recognition, multi-threaded, model hot-swap.
     """
     def __init__(self, status_callback: Callable[[str], None]):
-        """
-        初始化，传入状态回调函数用于UI进度提示
-        """
+        """Initialize with a status callback for UI progress updates."""
         self.status_callback = status_callback
-        # 默认初始化OCR模型
-        log.info("初始化 OCRLogic，加载默认模型")
+        # Initialize default OCR model
+        log.info("Initializing OCRLogic with default model")
         self.model = ONNXPaddleOcr(use_angle_cls=True, use_gpu=False)
 
     def run(self, files: List[str], save_txt: bool, merge_txt: bool, output_img: bool = False, file_time_callback=None, pdf_progress_callback=None, max_workers: int = 4):
         """
-        批量图片/PDF识别主入口，支持多线程加速
-        files: 待识别文件路径列表
-        save_txt: 是否保存txt
-        merge_txt: 是否合并为一个txt
-        output_img: 是否输出带框图片
-        file_time_callback: 单文件识别耗时回调
-        pdf_progress_callback: PDF页进度回调
-        max_workers: 最大线程数，默认4
+        Batch image/PDF recognition entry point with multi-threading.
+
+        Args:
+            files: List of file paths to recognize.
+            save_txt: Whether to save results as txt.
+            merge_txt: Whether to merge all results into one txt.
+            output_img: Whether to output annotated images.
+            file_time_callback: Callback for per-file processing time.
+            pdf_progress_callback: Callback for PDF page progress.
+            max_workers: Max thread count, default 4.
         """
         import concurrent.futures
         start_time = time.time()
-        all_text = [None] * len(files)  # 用于顺序合并结果
+        all_text = [None] * len(files)  # For ordered result merging
         def process_one(idx_file):
             idx, file = idx_file
             ext = os.path.splitext(file)[1].lower()
-            self.status_callback(f"正在处理: {os.path.basename(file)} ({idx+1}/{len(files)})")
+            self.status_callback(f"Processing: {os.path.basename(file)} ({idx+1}/{len(files)})")
             t0 = time.time()
             text = ""
             if ext == ".pdf":
-                # PDF转图片后识别
+                # Convert PDF to images then OCR
                 if pdf_to_images is None:
-                    raise RuntimeError("未安装pymupdf库，无法处理PDF文件。请先安装pymupdf。")
+                    raise RuntimeError("pymupdf is not installed, cannot process PDF files. Please install pymupdf first.")
                 images = pdf_to_images(file, dpi=300)
                 text = self._ocr_images(images, file, save_txt, merge_txt, output_img=output_img, is_pdf=True, pdf_progress_callback=pdf_progress_callback, max_workers=max_workers)
             else:
-                # 普通图片识别，兼容中文路径
+                # Regular image recognition, compatible with unicode paths
                 try:
                     if file.lower().endswith('.bmp'):
                         img = cv2.imdecode(np.fromfile(file, dtype=np.uint8), cv2.IMREAD_COLOR)
@@ -89,14 +87,14 @@ class OCRLogic:
                             img_array = np.frombuffer(fimg.read(), np.uint8)
                         img = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
                 except Exception as e:
-                    self.status_callback(f"图片读取失败: {file}，错误: {e}")
-                    log.error("图片读取失败: {}, 错误: {}", file, e)
+                    self.status_callback(f"Image read failed: {file}, error: {e}")
+                    log.error("Image read failed: {}, error: {}", file, e)
                     if file_time_callback:
                         file_time_callback(idx, 0)
                     return (idx, "")
                 if img is None:
-                    self.status_callback(f"文件无法读取或不是有效图片: {file}")
-                    log.warning("文件无法读取或不是有效图片: {}", file)
+                    self.status_callback(f"File is not a valid image: {file}")
+                    log.warning("File is not a valid image: {}", file)
                     if file_time_callback:
                         file_time_callback(idx, 0)
                     return (idx, "")
@@ -104,18 +102,18 @@ class OCRLogic:
             t1 = time.time()
             if file_time_callback:
                 file_time_callback(idx, t1-t0)
-            self.status_callback(f"{os.path.basename(file)} 识别用时: {t1-t0:.2f} 秒")
+            self.status_callback(f"{os.path.basename(file)} done in {t1-t0:.2f}s")
             if len(files) > 1:
                 avg = (t1 - start_time) / (idx + 1)
-                self.status_callback(f"已完成 {idx+1}/{len(files)}，平均单张用时: {avg:.2f} 秒")
+                self.status_callback(f"Completed {idx+1}/{len(files)}, avg {avg:.2f}s per file")
             return (idx, text)
-        # 多线程处理所有文件，结果按索引回填，保证顺序
+        # Multi-threaded processing, results filled by index to preserve order
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = [executor.submit(process_one, (idx, file)) for idx, file in enumerate(files)]
             for future in concurrent.futures.as_completed(futures):
                 idx, text = future.result()
                 all_text[idx] = text
-        # 合并写入txt
+        # Merge and write txt
         if save_txt and merge_txt and len(files) > 1:
             out_dir = self._get_output_dir(files[0])
             timestamp = time.strftime("%Y%m%d_%H%M%S")
@@ -126,23 +124,25 @@ class OCRLogic:
                         f.write(text)
                         f.write("\n\n")
         elapsed = time.time() - start_time
-        log.info("批量识别完成，共 {} 个文件，总耗时: {:.2f}秒", len(files), elapsed)
+        log.info("Batch recognition done: {} files, total time: {:.2f}s", len(files), elapsed)
         if files:
             out_dir = self._get_output_dir(files[0])
-            self.status_callback(f"识别完成，总耗时：{elapsed:.2f}秒，文件保存在：{out_dir}")
+            self.status_callback(f"Done in {elapsed:.2f}s, saved to: {out_dir}")
         else:
-            self.status_callback(f"识别完成，总耗时：{elapsed:.2f}秒")
+            self.status_callback(f"Done in {elapsed:.2f}s")
 
     def _ocr_images(self, images, pdf_path, save_txt, merge_txt, output_img=False, is_pdf=False, pdf_progress_callback=None, max_workers: int = 4):
         """
-        PDF转图片后，批量图片识别，支持多线程加速
-        images: PDF每页图片（numpy数组）
-        pdf_path: 原PDF路径
-        save_txt: 是否保存txt
-        merge_txt: 是否合并txt（未用）
-        output_img: 是否输出带框图片
-        pdf_progress_callback: 页进度回调
-        max_workers: 最大线程数，默认4
+        Batch OCR on PDF page images with multi-threading.
+
+        Args:
+            images: PDF page images as numpy arrays.
+            pdf_path: Original PDF path.
+            save_txt: Whether to save txt.
+            merge_txt: Whether to merge txt (unused).
+            output_img: Whether to output annotated images.
+            pdf_progress_callback: Page progress callback.
+            max_workers: Max thread count, default 4.
         """
         import concurrent.futures
         out_dir = self._get_output_dir(pdf_path)
@@ -158,7 +158,7 @@ class OCRLogic:
                 sav2Img(img_cv, result, name=out_img_path)
             page_text = self._result_to_text(result)
             return (i, page_text)
-        # 多线程识别每一页，结果按页码顺序合并
+        # Multi-threaded page recognition, merged by page order
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = [executor.submit(process_page, (i, img)) for i, img in enumerate(images)]
             for future in concurrent.futures.as_completed(futures):
@@ -173,9 +173,7 @@ class OCRLogic:
         return "\n\n".join(pdf_text)
 
     def _ocr_image(self, img, img_path, save_txt, output_img=False):
-        """
-        单张图片OCR识别，支持保存txt和输出带框图片
-        """
+        """OCR a single image, optionally saving txt and annotated image."""
         out_dir = self._get_output_dir(img_path)
         result = self.model.ocr(img)
         if output_img:
@@ -190,28 +188,24 @@ class OCRLogic:
         return text
 
     def _result_to_text(self, result):
-        """
-        将OCR识别结果结构化为纯文本，兼容只检测无识别内容的情况
-        """
-        # 健壮性检查，防止result为空或结构异常
+        """Convert OCR result to plain text, handling detection-only results."""
+        # Robustness check for empty or malformed results
         if not result or not isinstance(result, list) or not result[0] or not isinstance(result[0], list):
-            return "[未检测到内容]"
+            return "[No content detected]"
         lines = []
         for box in result[0]:
-            # 兼容只检测无识别内容的情况
+            # Handle detection-only results without recognition text
             if isinstance(box, list) and len(box) == 2 and isinstance(box[1], (list, tuple)) and len(box[1]) >= 1:
                 lines.append(str(box[1][0]))
             elif isinstance(box, list) and (isinstance(box[0], (list, tuple)) or isinstance(box[0], float)):
-                # 只有检测框，无识别内容
-                lines.append("[未识别] " + str(box))
+                # Detection box only, no recognition text
+                lines.append("[Unrecognized] " + str(box))
             else:
                 lines.append(str(box))
         return "\n".join(lines)
 
     def _get_output_dir(self, file_path):
-        """
-        获取输出目录，自动创建
-        """
+        """Get output directory, creating it if needed."""
         base_dir = os.path.dirname(file_path)
         out_dir = os.path.join(base_dir, "Output_OCR")
         os.makedirs(out_dir, exist_ok=True)
@@ -219,8 +213,10 @@ class OCRLogic:
 
     def set_model(self, model_name, use_gpu=False):
         """
-        切换OCR模型，支持多模型热切换，所有模型统一用ppocrv5字典
-        use_gpu: 是否启用GPU
+        Switch OCR model with hot-swap support. All models use ppocrv5 dictionary.
+
+        Args:
+            use_gpu: Whether to enable GPU inference.
         """
         import os
         import tkinter.messagebox as messagebox
@@ -238,7 +234,7 @@ class OCRLogic:
         rec_model_dir = os.path.join(model_path, "rec", "rec.onnx") if os.path.exists(os.path.join(model_path, "rec", "rec.onnx")) else None
         ocr_kwargs = dict(
             use_angle_cls=True,
-            use_gpu=use_gpu,  # 关键：传递GPU参数
+            use_gpu=use_gpu,
             det_model_dir=det_model_dir,
             cls_model_dir=cls_model_dir,
             rec_char_dict_path=rec_char_dict_path
@@ -247,30 +243,30 @@ class OCRLogic:
             ocr_kwargs["rec_model_dir"] = rec_model_dir
         try:
             self.model = ONNXPaddleOcr(**ocr_kwargs)
-            log.info("模型切换成功: {}", model_name)
+            log.info("Model switched successfully: {}", model_name)
             if use_gpu:
                 try:
                     providers = self.model.session.get_providers() if hasattr(self.model, 'session') else []
                     if not any('CUDA' in p for p in providers):
-                        msg = ("未检测到可用GPU，已自动切换为CPU推理。请检查CUDA/cuDNN环境配置。")
+                        msg = ("No GPU available, falling back to CPU. Check CUDA/cuDNN setup.")
                         if hasattr(self, 'ui_ref') and hasattr(self.ui_ref, 'update_gpu_status'):
                             self.ui_ref.update_gpu_status(msg)
                         if hasattr(self, 'status_callback'):
-                            self.status_callback("[警告] 未检测到可用GPU，已切换为CPU推理。请检查CUDA/cuDNN环境配置。")
+                            self.status_callback("[Warning] No GPU detected, switched to CPU. Check CUDA/cuDNN setup.")
                 except Exception:
-                    msg = ("检测GPU状态时发生异常，可能未正确安装CUDA/cuDNN或onnxruntime-gpu。已自动切换为CPU推理。")
+                    msg = ("GPU detection error, possibly missing CUDA/cuDNN or onnxruntime-gpu. Falling back to CPU.")
                     if hasattr(self, 'ui_ref') and hasattr(self.ui_ref, 'update_gpu_status'):
                         self.ui_ref.update_gpu_status(msg)
                     if hasattr(self, 'status_callback'):
-                        self.status_callback("[警告] GPU检测异常，已切换为CPU推理。请检查CUDA/cuDNN环境配置。")
+                        self.status_callback("[Warning] GPU detection failed, switched to CPU. Check CUDA/cuDNN setup.")
         except Exception as e:
-            log.error("模型切换失败: {}, 错误: {}", model_name, e)
+            log.error("Model switch failed: {}, error: {}", model_name, e)
             if use_gpu:
-                msg = f"GPU初始化失败，已自动切换为CPU。请检查CUDA/cuDNN环境配置。错误信息: {e}"
+                msg = f"GPU init failed, falling back to CPU. Check CUDA/cuDNN setup. Error: {e}"
                 if hasattr(self, 'ui_ref') and hasattr(self.ui_ref, 'update_gpu_status'):
                     self.ui_ref.update_gpu_status(msg)
                 if hasattr(self, 'status_callback'):
-                    self.status_callback("[警告] GPU初始化失败，已切换为CPU推理。请检查CUDA/cuDNN环境配置。")
+                    self.status_callback("[Warning] GPU init failed, switched to CPU. Check CUDA/cuDNN setup.")
                 ocr_kwargs["use_gpu"] = False
                 self.model = ONNXPaddleOcr(**ocr_kwargs)
             else:

--- a/onnxocr/onnx_paddleocr.py
+++ b/onnxocr/onnx_paddleocr.py
@@ -47,7 +47,7 @@ class ONNXPaddleOcr(TextSystem):
             )
 
         if self.use_plate_recognition:
-            log.info("初始化车牌识别模式")
+            log.info("Initializing plate recognition mode")
             self.plate_recognizer = LicensePlateRecognizer(
                 detect_model_path=plate_detect_model_path,
                 rec_model_path=plate_rec_model_path,
@@ -56,7 +56,7 @@ class ONNXPaddleOcr(TextSystem):
             return
 
         if self.use_layout_analysis:
-            log.info("初始化版面分析模式")
+            log.info("Initializing layout analysis mode")
             self.layout_recognizer = LayoutRecognizer(
                 model_type=layout_model_type,
                 model_path=layout_model_path,
@@ -76,10 +76,10 @@ class ONNXPaddleOcr(TextSystem):
         params.__dict__.update(**kwargs)
 
         super().__init__(params)
-        log.info("OCR 模型初始化完成: det={}, cls={}, rec={}", True, self.use_angle_cls, True)
+        log.info("OCR model initialized: det=True, cls={}, rec=True", self.use_angle_cls)
         self.table_recognizer = None
         if self.use_table_recognition:
-            log.info("初始化表格识别模式")
+            log.info("Initializing table recognition mode")
             self.table_recognizer = TableRecognizer(
                 model_type=table_model_type,
                 model_path=table_model_path,

--- a/onnxocr/onnx_paddleocr.py
+++ b/onnxocr/onnx_paddleocr.py
@@ -1,5 +1,6 @@
 import argparse
 import time
+from pathlib import Path
 
 from .layout_recognition import LayoutRecognizer
 from .license_plate import LicensePlateRecognizer
@@ -169,9 +170,11 @@ if __name__ == "__main__":
 
     model = ONNXPaddleOcr(use_angle_cls=True, use_gpu=False)
 
-    img = cv2.imread(
-        "/data2/liujingsong3/fiber_box/test/img/20230531230052008263304.jpg"
-    )
+    test_img = str(Path(__file__).resolve().parent / "test_images" / "715873facf064583b44ef28295126fa7.jpg")
+    img = cv2.imread(test_img)
+    if img is None:
+        log.error("Test image not found: {}", test_img)
+        raise SystemExit(1)
     s = time.time()
     result = model.ocr(img)
     e = time.time()

--- a/onnxocr/onnx_paddleocr.py
+++ b/onnxocr/onnx_paddleocr.py
@@ -3,6 +3,7 @@ import time
 
 from .layout_recognition import LayoutRecognizer
 from .license_plate import LicensePlateRecognizer
+from .logger import get_logger
 from .predict_system import TextSystem
 from .table_recognition import TableRecognizer
 from .utils import draw_ocr
@@ -12,6 +13,8 @@ from .visualization import (
     save_plate_visualization,
     save_table_visualization,
 )
+
+log = get_logger("onnx_paddleocr")
 
 
 class ONNXPaddleOcr(TextSystem):
@@ -44,6 +47,7 @@ class ONNXPaddleOcr(TextSystem):
             )
 
         if self.use_plate_recognition:
+            log.info("初始化车牌识别模式")
             self.plate_recognizer = LicensePlateRecognizer(
                 detect_model_path=plate_detect_model_path,
                 rec_model_path=plate_rec_model_path,
@@ -52,6 +56,7 @@ class ONNXPaddleOcr(TextSystem):
             return
 
         if self.use_layout_analysis:
+            log.info("初始化版面分析模式")
             self.layout_recognizer = LayoutRecognizer(
                 model_type=layout_model_type,
                 model_path=layout_model_path,
@@ -71,8 +76,10 @@ class ONNXPaddleOcr(TextSystem):
         params.__dict__.update(**kwargs)
 
         super().__init__(params)
+        log.info("OCR 模型初始化完成: det={}, cls={}, rec={}", True, self.use_angle_cls, True)
         self.table_recognizer = None
         if self.use_table_recognition:
+            log.info("初始化表格识别模式")
             self.table_recognizer = TableRecognizer(
                 model_type=table_model_type,
                 model_path=table_model_path,
@@ -98,7 +105,7 @@ class ONNXPaddleOcr(TextSystem):
 
     def _general_ocr(self, img, det=True, rec=True, cls=True):
         if cls is True and self.use_angle_cls is False:
-            print(
+            log.warning(
                 "Since the angle classifier is not initialized, the angle classifier will not be used during the forward process"
             )
 
@@ -168,9 +175,9 @@ if __name__ == "__main__":
     s = time.time()
     result = model.ocr(img)
     e = time.time()
-    print("total time: {:.3f}".format(e - s))
-    print("result:", result)
+    log.info("total time: {:.3f}", e - s)
+    log.info("result: {}", result)
     for box in result[0]:
-        print(box)
+        log.info("{}", box)
 
     sav2Img(img, result)

--- a/onnxocr/operators.py
+++ b/onnxocr/operators.py
@@ -3,6 +3,10 @@ import cv2
 import sys
 import math
 
+from .logger import get_logger
+
+log = get_logger("operators")
+
 
 class NormalizeImage(object):
     """ normalize image such as substract mean, divide std
@@ -130,9 +134,9 @@ class DetResizeForTest(object):
             if int(resize_w) <= 0 or int(resize_h) <= 0:
                 return None, (None, None)
             img = cv2.resize(img, (int(resize_w), int(resize_h)))
-        except:
-            print(img.shape, resize_w, resize_h)
-            sys.exit(0)
+        except Exception as e:
+            log.error("图像 resize 失败: shape={}, resize_w={}, resize_h={}, 错误: {}", img.shape, resize_w, resize_h, e)
+            raise RuntimeError(f"Image resize failed: shape={img.shape}, target=({resize_w}, {resize_h})") from e
         ratio_h = resize_h / float(h)
         ratio_w = resize_w / float(w)
         return img, [ratio_h, ratio_w]

--- a/onnxocr/operators.py
+++ b/onnxocr/operators.py
@@ -135,7 +135,7 @@ class DetResizeForTest(object):
                 return None, (None, None)
             img = cv2.resize(img, (int(resize_w), int(resize_h)))
         except Exception as e:
-            log.error("图像 resize 失败: shape={}, resize_w={}, resize_h={}, 错误: {}", img.shape, resize_w, resize_h, e)
+            log.error("Image resize failed: shape={}, target=({},{}) error: {}", img.shape, resize_w, resize_h, e)
             raise RuntimeError(f"Image resize failed: shape={img.shape}, target=({resize_w}, {resize_h})") from e
         ratio_h = resize_h / float(h)
         ratio_w = resize_w / float(w)

--- a/onnxocr/orientation.py
+++ b/onnxocr/orientation.py
@@ -7,6 +7,9 @@ import cv2
 import numpy as np
 
 from .inference_engine import create_session
+from .logger import get_logger
+
+log = get_logger("orientation")
 
 
 DEFAULT_ORIENTATION_MODEL = (
@@ -34,6 +37,7 @@ class RapidOrientationClassifier:
         self.input_name = self.session.get_inputs()[0].name
         self.output_names = [item.name for item in self.session.get_outputs()]
         self.labels = self._load_labels()
+        log.info("方向分类器加载完成: {}", self.model_path)
 
     def __call__(self, img_list: List[np.ndarray]) -> Tuple[List[np.ndarray], List[List]]:
         img_list = [self._ensure_bgr(img).copy() for img in img_list]

--- a/onnxocr/orientation.py
+++ b/onnxocr/orientation.py
@@ -37,7 +37,7 @@ class RapidOrientationClassifier:
         self.input_name = self.session.get_inputs()[0].name
         self.output_names = [item.name for item in self.session.get_outputs()]
         self.labels = self._load_labels()
-        log.info("方向分类器加载完成: {}", self.model_path)
+        log.info("Orientation classifier loaded: {}", self.model_path)
 
     def __call__(self, img_list: List[np.ndarray]) -> Tuple[List[np.ndarray], List[List]]:
         img_list = [self._ensure_bgr(img).copy() for img in img_list]

--- a/onnxocr/predict_base.py
+++ b/onnxocr/predict_base.py
@@ -1,4 +1,7 @@
 from .inference_engine import create_session
+from .logger import get_logger
+
+log = get_logger("predict_base")
 
 
 class PredictBase(object):
@@ -6,6 +9,7 @@ class PredictBase(object):
         pass
 
     def get_onnx_session(self, model_dir, use_gpu, gpu_id=0):
+        log.debug("获取 ONNX session: {}, use_gpu={}, gpu_id={}", model_dir, use_gpu, gpu_id)
         return create_session(model_dir, use_gpu=use_gpu, gpu_id=gpu_id)
 
     def get_output_name(self, onnx_session):

--- a/onnxocr/predict_base.py
+++ b/onnxocr/predict_base.py
@@ -9,7 +9,7 @@ class PredictBase(object):
         pass
 
     def get_onnx_session(self, model_dir, use_gpu, gpu_id=0):
-        log.debug("获取 ONNX session: {}, use_gpu={}, gpu_id={}", model_dir, use_gpu, gpu_id)
+        log.debug("Getting ONNX session: {}, use_gpu={}, gpu_id={}", model_dir, use_gpu, gpu_id)
         return create_session(model_dir, use_gpu=use_gpu, gpu_id=gpu_id)
 
     def get_output_name(self, onnx_session):

--- a/onnxocr/predict_cls.py
+++ b/onnxocr/predict_cls.py
@@ -4,7 +4,10 @@ import numpy as np
 import math
 
 from .cls_postprocess import ClsPostProcess
+from .logger import get_logger
 from .predict_base import PredictBase
+
+log = get_logger("predict_cls")
 
 
 class TextClassifier(PredictBase):
@@ -18,6 +21,7 @@ class TextClassifier(PredictBase):
         self.cls_onnx_session = self.get_onnx_session(args.cls_model_dir, args.use_gpu, gpu_id = args.gpu_id)
         self.cls_input_name = self.get_input_name(self.cls_onnx_session)
         self.cls_output_name = self.get_output_name(self.cls_onnx_session)
+        log.info("分类模型加载完成: {}", args.cls_model_dir)
 
     def resize_norm_img(self, img):
         imgC, imgH, imgW = self.cls_image_shape

--- a/onnxocr/predict_cls.py
+++ b/onnxocr/predict_cls.py
@@ -17,11 +17,11 @@ class TextClassifier(PredictBase):
         self.cls_thresh = args.cls_thresh
         self.postprocess_op = ClsPostProcess(label_list=args.label_list)
 
-        # 初始化模型
+        # Initialize model
         self.cls_onnx_session = self.get_onnx_session(args.cls_model_dir, args.use_gpu, gpu_id = args.gpu_id)
         self.cls_input_name = self.get_input_name(self.cls_onnx_session)
         self.cls_output_name = self.get_output_name(self.cls_onnx_session)
-        log.info("分类模型加载完成: {}", args.cls_model_dir)
+        log.info("Classification model loaded: {}", args.cls_model_dir)
 
     def resize_norm_img(self, img):
         imgC, imgH, imgW = self.cls_image_shape

--- a/onnxocr/predict_det.py
+++ b/onnxocr/predict_det.py
@@ -41,17 +41,17 @@ class TextDetector(PredictBase):
         postprocess_params["score_mode"] = args.det_db_score_mode
         postprocess_params["box_type"] = args.det_box_type
 
-        # 实例化预处理操作类
+        # Instantiate preprocess ops
         self.preprocess_op = create_operators(pre_process_list)
         # self.postprocess_op = build_post_process(postprocess_params)
-        # 实例化后处理操作类
+        # Instantiate postprocess ops
         self.postprocess_op = DBPostProcess(**postprocess_params)
 
-        # 初始化模型
+        # Initialize model
         self.det_onnx_session = self.get_onnx_session(args.det_model_dir, args.use_gpu, gpu_id = args.gpu_id)
         self.det_input_name = self.get_input_name(self.det_onnx_session)
         self.det_output_name = self.get_output_name(self.det_onnx_session)
-        log.info("检测模型加载完成: {}", args.det_model_dir)
+        log.info("Detection model loaded: {}", args.det_model_dir)
 
     def order_points_clockwise(self, pts):
         rect = np.zeros((4, 2), dtype="float32")
@@ -112,7 +112,7 @@ class TextDetector(PredictBase):
         input_feed = self.get_input_feed(self.det_input_name, img)
         t0 = time.time()
         outputs = self.det_onnx_session.run(self.det_output_name, input_feed=input_feed)
-        log.debug("检测推理耗时: {:.3f}s", time.time() - t0)
+        log.debug("Detection inference time: {:.3f}s", time.time() - t0)
 
         preds = {}
         preds["maps"] = outputs[0]

--- a/onnxocr/predict_det.py
+++ b/onnxocr/predict_det.py
@@ -1,7 +1,12 @@
+import time
+
 import numpy as np
 from .imaug import transform, create_operators
 from .db_postprocess import DBPostProcess
+from .logger import get_logger
 from .predict_base import PredictBase
+
+log = get_logger("predict_det")
 
 
 class TextDetector(PredictBase):
@@ -46,6 +51,7 @@ class TextDetector(PredictBase):
         self.det_onnx_session = self.get_onnx_session(args.det_model_dir, args.use_gpu, gpu_id = args.gpu_id)
         self.det_input_name = self.get_input_name(self.det_onnx_session)
         self.det_output_name = self.get_output_name(self.det_onnx_session)
+        log.info("检测模型加载完成: {}", args.det_model_dir)
 
     def order_points_clockwise(self, pts):
         rect = np.zeros((4, 2), dtype="float32")
@@ -104,7 +110,9 @@ class TextDetector(PredictBase):
         img = img.copy()
 
         input_feed = self.get_input_feed(self.det_input_name, img)
+        t0 = time.time()
         outputs = self.det_onnx_session.run(self.det_output_name, input_feed=input_feed)
+        log.debug("检测推理耗时: {:.3f}s", time.time() - t0)
 
         preds = {}
         preds["maps"] = outputs[0]

--- a/onnxocr/predict_rec.py
+++ b/onnxocr/predict_rec.py
@@ -21,11 +21,11 @@ class TextRecognizer(PredictBase):
             use_space_char=args.use_space_char,
         )
 
-        # 初始化模型
+        # Initialize model
         self.rec_onnx_session = self.get_onnx_session(args.rec_model_dir, args.use_gpu, gpu_id = args.gpu_id)
         self.rec_input_name = self.get_input_name(self.rec_onnx_session)
         self.rec_output_name = self.get_output_name(self.rec_onnx_session)
-        log.info("识别模型加载完成: {}", args.rec_model_dir)
+        log.info("Recognition model loaded: {}", args.rec_model_dir)
 
     def resize_norm_img(self, img, max_wh_ratio):
         imgC, imgH, imgW = self.rec_image_shape

--- a/onnxocr/predict_rec.py
+++ b/onnxocr/predict_rec.py
@@ -5,7 +5,10 @@ from PIL import Image
 
 
 from .rec_postprocess import CTCLabelDecode
+from .logger import get_logger
 from .predict_base import PredictBase
+
+log = get_logger("predict_rec")
 
 
 class TextRecognizer(PredictBase):
@@ -22,6 +25,7 @@ class TextRecognizer(PredictBase):
         self.rec_onnx_session = self.get_onnx_session(args.rec_model_dir, args.use_gpu, gpu_id = args.gpu_id)
         self.rec_input_name = self.get_input_name(self.rec_onnx_session)
         self.rec_output_name = self.get_output_name(self.rec_onnx_session)
+        log.info("识别模型加载完成: {}", args.rec_model_dir)
 
     def resize_norm_img(self, img, max_wh_ratio):
         imgC, imgH, imgW = self.rec_image_shape
@@ -53,12 +57,6 @@ class TextRecognizer(PredictBase):
 
         assert imgC == img.shape[2]
         imgW = int((imgH * max_wh_ratio))
-
-        # w = self.rec_onnx_session.get_inputs()[0].shape[3:][0]
-        # w = self.rec_onnx_session.get_inputs()[0].shape[3:][0]
-        # print(w)
-        # if w is not None and w > 0:
-        #     imgW = w
 
         h, w = img.shape[:2]
         ratio = w / float(h)
@@ -306,12 +304,6 @@ class TextRecognizer(PredictBase):
             norm_img_batch = np.concatenate(norm_img_batch)
             norm_img_batch = norm_img_batch.copy()
 
-            # img = img[:, :, ::-1].transpose(2, 0, 1)
-            # img = img[:, :, ::-1]
-            # img = img.transpose(2, 0, 1)
-            # img = img.astype(np.float32)
-            # img = np.expand_dims(img, axis=0)
-            # print(img.shape)
             input_feed = self.get_input_feed(self.rec_input_name, norm_img_batch)
             outputs = self.rec_onnx_session.run(
                 self.rec_output_name, input_feed=input_feed

--- a/onnxocr/predict_system.py
+++ b/onnxocr/predict_system.py
@@ -4,8 +4,11 @@ import copy
 from . import predict_det
 from . import predict_cls
 from . import predict_rec
+from .logger import get_logger
 from .orientation import RapidOrientationClassifier
 from .utils import get_rotate_crop_image, get_minarea_rect_crop
+
+log = get_logger("predict_system")
 
 
 class TextSystem(object):
@@ -38,10 +41,12 @@ class TextSystem(object):
 
     def __call__(self, img, cls=True):
         ori_im = img.copy()
+        log.debug("开始 OCR 管道处理, 图像形状: {}", img.shape)
         # 文字检测
         dt_boxes = self.text_detector(img)
 
         if dt_boxes is None:
+            log.warning("未检测到文本区域")
             return None, None
 
         img_crop_list = []
@@ -73,6 +78,7 @@ class TextSystem(object):
                 filter_boxes.append(box)
                 filter_rec_res.append(rec_result)
 
+        log.debug("OCR 管道处理完成, 检测到 {} 个文本区域, 保留 {} 个", len(dt_boxes), len(filter_boxes))
         return filter_boxes, filter_rec_res
 
 

--- a/onnxocr/predict_system.py
+++ b/onnxocr/predict_system.py
@@ -41,19 +41,19 @@ class TextSystem(object):
 
     def __call__(self, img, cls=True):
         ori_im = img.copy()
-        log.debug("开始 OCR 管道处理, 图像形状: {}", img.shape)
-        # 文字检测
+        log.debug("OCR pipeline started, image shape: {}", img.shape)
+        # Text detection
         dt_boxes = self.text_detector(img)
 
         if dt_boxes is None:
-            log.warning("未检测到文本区域")
+            log.warning("No text regions detected")
             return None, None
 
         img_crop_list = []
 
         dt_boxes = sorted_boxes(dt_boxes)
 
-        # 图片裁剪
+        # Image crop
         for bno in range(len(dt_boxes)):
             tmp_box = copy.deepcopy(dt_boxes[bno])
             if self.args.det_box_type == "quad":
@@ -62,11 +62,11 @@ class TextSystem(object):
                 img_crop = get_minarea_rect_crop(ori_im, tmp_box)
             img_crop_list.append(img_crop)
 
-        # 方向分类
+        # Orientation classification
         if self.use_angle_cls and cls:
             img_crop_list, angle_list = self.text_classifier(img_crop_list)
 
-        # 图像识别
+        # Text recognition
         rec_res = self.text_recognizer(img_crop_list)
 
         if self.args.save_crop_res:
@@ -78,7 +78,7 @@ class TextSystem(object):
                 filter_boxes.append(box)
                 filter_rec_res.append(rec_result)
 
-        log.debug("OCR 管道处理完成, 检测到 {} 个文本区域, 保留 {} 个", len(dt_boxes), len(filter_boxes))
+        log.debug("OCR pipeline done, {} regions detected, {} kept", len(dt_boxes), len(filter_boxes))
         return filter_boxes, filter_rec_res
 
 

--- a/onnxocr/table_recognition.py
+++ b/onnxocr/table_recognition.py
@@ -3,7 +3,10 @@ from typing import Dict, List, Optional
 
 import numpy as np
 
+from .logger import get_logger
 from .rapid_table import ModelType, RapidTable, RapidTableInput
+
+log = get_logger("table_recognition")
 
 
 TABLE_MODEL_PATHS = {
@@ -40,6 +43,7 @@ class TableRecognizer:
         self.model_type = model_type
         self.model_path = model_path
         self.table_engine = RapidTable(input_args)
+        log.info("表格识别模型加载完成: type={}, path={}", model_type, model_path)
 
     def recognize(self, img: np.ndarray, ocr_result: List) -> Dict:
         if img is None or not isinstance(img, np.ndarray):

--- a/onnxocr/table_recognition.py
+++ b/onnxocr/table_recognition.py
@@ -43,7 +43,7 @@ class TableRecognizer:
         self.model_type = model_type
         self.model_path = model_path
         self.table_engine = RapidTable(input_args)
-        log.info("表格识别模型加载完成: type={}, path={}", model_type, model_path)
+        log.info("Table recognition model loaded: type={}, path={}", model_type, model_path)
 
     def recognize(self, img: np.ndarray, ocr_result: List) -> Dict:
         if img is None or not isinstance(img, np.ndarray):

--- a/onnxocr/utils.py
+++ b/onnxocr/utils.py
@@ -9,7 +9,7 @@ from .logger import get_logger
 
 log = get_logger("utils")
 
-# 获取当前文件所在的目录
+# Current module directory
 module_dir = Path(__file__).resolve().parent
 
 

--- a/onnxocr/utils.py
+++ b/onnxocr/utils.py
@@ -5,6 +5,10 @@ import math
 from PIL import Image, ImageDraw, ImageFont
 from pathlib import Path
 
+from .logger import get_logger
+
+log = get_logger("utils")
+
 # 获取当前文件所在的目录
 module_dir = Path(__file__).resolve().parent
 

--- a/onnxocr/visualization.py
+++ b/onnxocr/visualization.py
@@ -18,7 +18,7 @@ def _load_font(font_path: str, size: int):
     try:
         return ImageFont.truetype(font_path, size, encoding="utf-8")
     except Exception:
-        log.warning("字体加载失败，使用默认字体: {}", font_path)
+        log.warning("Font load failed, using default: {}", font_path)
         return ImageFont.load_default()
 
 

--- a/onnxocr/visualization.py
+++ b/onnxocr/visualization.py
@@ -5,6 +5,10 @@ import cv2
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
+from .logger import get_logger
+
+log = get_logger("visualization")
+
 
 MODULE_DIR = Path(__file__).resolve().parent
 DEFAULT_FONT_PATH = str(MODULE_DIR / "fonts" / "simfang.ttf")
@@ -14,6 +18,7 @@ def _load_font(font_path: str, size: int):
     try:
         return ImageFont.truetype(font_path, size, encoding="utf-8")
     except Exception:
+        log.warning("字体加载失败，使用默认字体: {}", font_path)
         return ImageFont.load_default()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 flask
 gunicorn
-opencv-python-headless==4.7.0.72
-opencv-contrib-python==4.7.0.72
-onnxruntime-gpu==1.14.1
+opencv-python-headless
+opencv-contrib-python-headless
+onnxruntime-gpu==1.16
+onnxruntime
 requests
 shapely
 pyclipper
@@ -14,7 +15,6 @@ numpy<2.0.0
 pymupdf
 pdf2image
 omegaconf
-colorlog
 loguru
 pypdfium2
 pypdf


### PR DESCRIPTION
- 重写 onnxocr/logger.py 为基于 loguru 的统一日志模块
- 提供 get_logger()、add_file_sink()、InterceptHandler
- 桥接 rapid_layout/rapid_table 的 logging 输出到 loguru
- 替换核心模块中所有 print() 为结构化 logger 调用
- operators.py 中 print()+sys.exit() 改为 logger.error()+raise
- 各模块添加模型加载、推理耗时、异常等关键日志
- requirements.txt 移除 colorlog，改用 opencv-contrib-python-headless