### PR TITLE
Refactor redundant code

### DIFF
--- a/app-service.py
+++ b/app-service.py
@@ -1,12 +1,8 @@
-import cv2
 import time
-import base64
 import os
-import numpy as np
-from flask import Flask, request, jsonify,render_template
+from flask import Flask, request, jsonify, render_template
 from werkzeug.utils import secure_filename
-from onnxocr.layout_markdown import LayoutMarkdownConverter
-from onnxocr.onnx_paddleocr import ONNXPaddleOcr
+from onnxocr.api_utils import ModelRegistry, decode_base64_image, format_ocr_results
 from onnxocr.visualization import (
     draw_layout_analysis,
     draw_plate_recognition,
@@ -14,54 +10,12 @@ from onnxocr.visualization import (
     image_to_base64,
 )
 
-# 初始化 Flask 应用
 app = Flask(__name__)
+models = ModelRegistry(use_gpu=False)
 
-# 初始化 OCR 模型
-model = ONNXPaddleOcr(use_angle_cls=True, use_gpu=False)
-plate_model = None
-table_model = None
-layout_models = {}
-layout_markdown_converters = {}
+RESULT_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "results")
+os.makedirs(RESULT_ROOT, exist_ok=True)
 
-
-def get_plate_model():
-    global plate_model
-    if plate_model is None:
-        plate_model = ONNXPaddleOcr(use_plate_recognition=True, use_gpu=False)
-    return plate_model
-
-
-def get_table_model():
-    global table_model
-    if table_model is None:
-        table_model = ONNXPaddleOcr(use_angle_cls=True, use_gpu=False, use_table_recognition=True)
-    return table_model
-
-
-def get_layout_model(model_type="pp_layout_cdla", conf_thresh=0.5, iou_thresh=0.5):
-    key = (model_type, float(conf_thresh), float(iou_thresh))
-    if key not in layout_models:
-        layout_models[key] = ONNXPaddleOcr(
-            use_layout_analysis=True,
-            use_gpu=False,
-            layout_model_type=model_type,
-            layout_conf_thresh=float(conf_thresh),
-            layout_iou_thresh=float(iou_thresh),
-        )
-    return layout_models[key]
-
-
-def get_layout_markdown_converter(model_type="pp_doclayoutv2", conf_thresh=0.4, iou_thresh=0.5):
-    key = (model_type, float(conf_thresh), float(iou_thresh))
-    if key not in layout_markdown_converters:
-        layout_markdown_converters[key] = LayoutMarkdownConverter(
-            layout_model_type=model_type,
-            layout_conf_thresh=float(conf_thresh),
-            layout_iou_thresh=float(iou_thresh),
-            ocr_kwargs={"use_angle_cls": True, "use_gpu": False},
-        )
-    return layout_markdown_converters[key]
 
 @app.route('/')
 def index():
@@ -70,52 +24,25 @@ def index():
 @app.route('/ocr', methods=['POST'])
 def ocr_service():
     try:
-        # 获取请求数据
         data = request.get_json()
         if not data or "image" not in data:
             return jsonify({"error": "Invalid request, 'image' field is required."}), 400
 
-        # 解码 base64 图像
-        image_base64 = data["image"]
         try:
-            image_bytes = base64.b64decode(image_base64)
-            image_np = np.frombuffer(image_bytes, dtype=np.uint8)
-            img = cv2.imdecode(image_np, cv2.IMREAD_COLOR)
-            if img is None:
-                return jsonify({"error": "Failed to decode image from base64."}), 400
-        except Exception as e:
+            img = decode_base64_image(data["image"])
+        except (ValueError, Exception) as e:
             return jsonify({"error": f"Image decoding failed: {str(e)}"}), 400
 
-        # 执行 OCR
         start_time = time.time()
-        result = model.ocr(img)
-        end_time = time.time()
-        processing_time = end_time - start_time
+        result = models.get_ocr_model().ocr(img)
+        processing_time = time.time() - start_time
 
-        # 格式化结果
-        ocr_results = []
-        for line in result[0]:
-            # 确保 line[0] 是 NumPy 数组或列表
-            if isinstance(line[0], (list, np.ndarray)):
-                # 将 bounding_box 转换为 [[x1, y1], [x2, y2], [x3, y3], [x4, y4]] 格式
-                bounding_box = np.array(line[0]).reshape(4, 2).tolist()  # 转换为 4x2 列表
-            else:
-                bounding_box = []
-
-            ocr_results.append({
-                "text": line[1][0],  # 识别文本
-                "confidence": float(line[1][1]),  # 置信度
-                "bounding_box": bounding_box  # 文本框坐标
-            })
-
-        # 返回结果
         return jsonify({
             "processing_time": processing_time,
-            "results": ocr_results
+            "results": format_ocr_results(result)
         })
 
     except Exception as e:
-        # 捕获所有异常并返回错误信息
         return jsonify({"error": f"An error occurred: {str(e)}"}), 500
 
 
@@ -132,12 +59,8 @@ def plate_service():
             return jsonify({"error": "'min_score' must be a number."}), 400
 
         start_time = time.time()
-        image_bytes = base64.b64decode(data["image"])
-        image_np = np.frombuffer(image_bytes, dtype=np.uint8)
-        img = cv2.imdecode(image_np, cv2.IMREAD_COLOR)
-        if img is None:
-            return jsonify({"error": "Failed to decode image from base64."}), 400
-        results = get_plate_model().ocr(img, plate_min_score=min_score)
+        img = decode_base64_image(data["image"])
+        results = models.get_plate_model().ocr(img, plate_min_score=min_score)
         processing_time = time.time() - start_time
 
         response = {
@@ -148,6 +71,8 @@ def plate_service():
             response["visualization"] = image_to_base64(draw_plate_recognition(img, results))
         return jsonify(response)
 
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
     except Exception as e:
         return jsonify({"error": f"An error occurred: {str(e)}"}), 500
 
@@ -159,16 +84,10 @@ def table_service():
         if not data or "image" not in data:
             return jsonify({"error": "Invalid request, 'image' field is required."}), 400
 
-        image_bytes = base64.b64decode(data["image"])
-        image_np = np.frombuffer(image_bytes, dtype=np.uint8)
-        img = cv2.imdecode(image_np, cv2.IMREAD_COLOR)
-        if img is None:
-            return jsonify({"error": "Failed to decode image from base64."}), 400
-
+        img = decode_base64_image(data["image"])
         start_time = time.time()
-        result = get_table_model().ocr(img)
-        processing_time = time.time() - start_time
-        result["processing_time"] = processing_time
+        result = models.get_table_model().ocr(img)
+        result["processing_time"] = time.time() - start_time
         if data.get("visualize", False):
             result["visualization"] = image_to_base64(
                 draw_table_recognition(img, result, show_logic=data.get("show_logic", False))
@@ -176,6 +95,8 @@ def table_service():
 
         return jsonify(result)
 
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
     except Exception as e:
         return jsonify({"error": f"An error occurred: {str(e)}"}), 500
 
@@ -187,23 +108,20 @@ def layout_service():
         if not data or "image" not in data:
             return jsonify({"error": "Invalid request, 'image' field is required."}), 400
 
-        image_bytes = base64.b64decode(data["image"])
-        image_np = np.frombuffer(image_bytes, dtype=np.uint8)
-        img = cv2.imdecode(image_np, cv2.IMREAD_COLOR)
-        if img is None:
-            return jsonify({"error": "Failed to decode image from base64."}), 400
-
+        img = decode_base64_image(data["image"])
         model_type = data.get("model_type", "pp_doclayoutv2")
         conf_thresh = float(data.get("conf_thresh", 0.4))
         iou_thresh = float(data.get("iou_thresh", 0.5))
         start_time = time.time()
-        result = get_layout_model(model_type, conf_thresh, iou_thresh).ocr(img)
+        result = models.get_layout_model(model_type, conf_thresh, iou_thresh).ocr(img)
         result["processing_time"] = time.time() - start_time
         if data.get("visualize", False):
             result["visualization"] = image_to_base64(draw_layout_analysis(img, result))
 
         return jsonify(result)
 
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
     except Exception as e:
         return jsonify({"error": f"An error occurred: {str(e)}"}), 500
 
@@ -215,24 +133,19 @@ def layout_markdown_service():
         if not data or "image" not in data:
             return jsonify({"error": "Invalid request, 'image' field is required."}), 400
 
-        image_bytes = base64.b64decode(data["image"])
-        image_np = np.frombuffer(image_bytes, dtype=np.uint8)
-        img = cv2.imdecode(image_np, cv2.IMREAD_COLOR)
-        if img is None:
-            return jsonify({"error": "Failed to decode image from base64."}), 400
-
+        img = decode_base64_image(data["image"])
         model_type = data.get("model_type", "pp_layout_cdla")
         conf_thresh = float(data.get("conf_thresh", 0.5))
         iou_thresh = float(data.get("iou_thresh", 0.5))
         timestamp = time.strftime("%Y%m%d_%H%M%S")
-        result_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "results", timestamp)
+        result_dir = os.path.join(RESULT_ROOT, timestamp)
         os.makedirs(result_dir, exist_ok=True)
         filename = secure_filename(data.get("filename", "layout_markdown.md")) or "layout_markdown.md"
         if not filename.lower().endswith(".md"):
             filename = f"{filename}.md"
         output_md_path = os.path.join(result_dir, filename)
 
-        result = get_layout_markdown_converter(model_type, conf_thresh, iou_thresh).convert_images(
+        result = models.get_layout_markdown_converter(model_type, conf_thresh, iou_thresh).convert_images(
             [img],
             output_md_path=output_md_path,
             source_name=os.path.splitext(os.path.basename(output_md_path))[0],
@@ -242,10 +155,11 @@ def layout_markdown_service():
 
         return jsonify(result)
 
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
     except Exception as e:
         return jsonify({"error": f"An error occurred: {str(e)}"}), 500
 
 
 if __name__ == '__main__':
-    # 启动 Flask 服务
     app.run(host="0.0.0.0", port=5005, debug=False)

--- a/onnxocr/api_utils.py
+++ b/onnxocr/api_utils.py
@@ -1,0 +1,86 @@
+"""Shared utilities for OnnxOCR API services."""
+import base64
+import cv2
+import numpy as np
+from onnxocr.onnx_paddleocr import ONNXPaddleOcr
+from onnxocr.layout_markdown import LayoutMarkdownConverter
+
+
+def decode_base64_image(image_base64: str) -> np.ndarray:
+    """Decode a base64-encoded string into an OpenCV BGR image.
+
+    Raises:
+        ValueError: If the data cannot be decoded into a valid image.
+    """
+    image_bytes = base64.b64decode(image_base64)
+    image_np = np.frombuffer(image_bytes, dtype=np.uint8)
+    img = cv2.imdecode(image_np, cv2.IMREAD_COLOR)
+    if img is None:
+        raise ValueError("Failed to decode image from base64.")
+    return img
+
+
+def format_ocr_results(result) -> list:
+    """Format raw OCR output into a list of dicts with text, confidence, bounding_box."""
+    ocr_results = []
+    for line in result[0]:
+        if isinstance(line[0], (list, np.ndarray)):
+            bounding_box = np.array(line[0]).reshape(4, 2).tolist()
+        else:
+            bounding_box = []
+        ocr_results.append({
+            "text": line[1][0],
+            "confidence": float(line[1][1]),
+            "bounding_box": bounding_box,
+        })
+    return ocr_results
+
+
+class ModelRegistry:
+    """Lazy-initialized, cached model registry for API services."""
+
+    def __init__(self, use_gpu: bool = False):
+        self._use_gpu = use_gpu
+        self._ocr_model = None
+        self._plate_model = None
+        self._table_model = None
+        self._layout_models = {}
+        self._layout_markdown_converters = {}
+
+    def get_ocr_model(self) -> ONNXPaddleOcr:
+        if self._ocr_model is None:
+            self._ocr_model = ONNXPaddleOcr(use_angle_cls=True, use_gpu=self._use_gpu)
+        return self._ocr_model
+
+    def get_plate_model(self) -> ONNXPaddleOcr:
+        if self._plate_model is None:
+            self._plate_model = ONNXPaddleOcr(use_plate_recognition=True, use_gpu=self._use_gpu)
+        return self._plate_model
+
+    def get_table_model(self) -> ONNXPaddleOcr:
+        if self._table_model is None:
+            self._table_model = ONNXPaddleOcr(use_angle_cls=True, use_gpu=self._use_gpu, use_table_recognition=True)
+        return self._table_model
+
+    def get_layout_model(self, model_type="pp_layout_cdla", conf_thresh=0.5, iou_thresh=0.5) -> ONNXPaddleOcr:
+        key = (model_type, float(conf_thresh), float(iou_thresh))
+        if key not in self._layout_models:
+            self._layout_models[key] = ONNXPaddleOcr(
+                use_layout_analysis=True,
+                use_gpu=self._use_gpu,
+                layout_model_type=model_type,
+                layout_conf_thresh=float(conf_thresh),
+                layout_iou_thresh=float(iou_thresh),
+            )
+        return self._layout_models[key]
+
+    def get_layout_markdown_converter(self, model_type="pp_doclayoutv2", conf_thresh=0.4, iou_thresh=0.5) -> LayoutMarkdownConverter:
+        key = (model_type, float(conf_thresh), float(iou_thresh))
+        if key not in self._layout_markdown_converters:
+            self._layout_markdown_converters[key] = LayoutMarkdownConverter(
+                layout_model_type=model_type,
+                layout_conf_thresh=float(conf_thresh),
+                layout_iou_thresh=float(iou_thresh),
+                ocr_kwargs={"use_angle_cls": True, "use_gpu": self._use_gpu},
+            )
+        return self._layout_markdown_converters[key]

--- a/onnxocr/utils.py
+++ b/onnxocr/utils.py
@@ -255,7 +255,7 @@ def str2bool(v):
 def infer_args():
     parser = argparse.ArgumentParser()
     # params for prediction engine
-    parser.add_argument("--use_gpu", type=str2bool, default=True)
+    parser.add_argument("--use_gpu", type=str2bool, default=False)
     parser.add_argument("--use_xpu", type=str2bool, default=False)
     parser.add_argument("--use_npu", type=str2bool, default=False)
     parser.add_argument("--ir_optim", type=str2bool, default=True)

--- a/onnxocr/utils.py
+++ b/onnxocr/utils.py
@@ -255,7 +255,7 @@ def str2bool(v):
 def infer_args():
     parser = argparse.ArgumentParser()
     # params for prediction engine
-    parser.add_argument("--use_gpu", type=str2bool, default=False)
+    parser.add_argument("--use_gpu", type=str2bool, default=True)
     parser.add_argument("--use_xpu", type=str2bool, default=False)
     parser.add_argument("--use_npu", type=str2bool, default=False)
     parser.add_argument("--ir_optim", type=str2bool, default=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ flask
 gunicorn
 opencv-python-headless
 opencv-contrib-python-headless
-onnxruntime-gpu==1.16
 onnxruntime
 requests
 shapely

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ flask
 gunicorn
 opencv-python-headless
 opencv-contrib-python-headless
-onnxruntime
+onnxruntime-gpu==1.16
 requests
 shapely
 pyclipper

--- a/webui.py
+++ b/webui.py
@@ -3,12 +3,8 @@ import time
 import zipfile
 from flask import Flask, render_template, request, jsonify, send_file, redirect, url_for
 from werkzeug.utils import secure_filename
-from onnxocr.layout_markdown import LayoutMarkdownConverter
 from onnxocr.ocr_images_pdfs import OCRLogic
-import cv2
-import base64
-import numpy as np
-from onnxocr.onnx_paddleocr import ONNXPaddleOcr
+from onnxocr.api_utils import ModelRegistry, decode_base64_image, format_ocr_results
 from onnxocr.visualization import (
     draw_layout_analysis,
     draw_plate_recognition,
@@ -28,51 +24,7 @@ app = Flask(__name__, static_folder="static", template_folder="templates")
 app.config['MAX_CONTENT_LENGTH'] = 200 * 1024 * 1024  # 200MB
 
 ocr_logic = OCRLogic(lambda msg: print(msg))
-# 独立 OCR 模型实例，避免影响 ocr_logic
-ocr_model_api = ONNXPaddleOcr(use_angle_cls=True, use_gpu=False)
-plate_model_api = None
-table_model_api = None
-layout_models_api = {}
-layout_markdown_converters_api = {}
-
-
-def get_plate_model():
-    global plate_model_api
-    if plate_model_api is None:
-        plate_model_api = ONNXPaddleOcr(use_plate_recognition=True, use_gpu=False)
-    return plate_model_api
-
-
-def get_table_model():
-    global table_model_api
-    if table_model_api is None:
-        table_model_api = ONNXPaddleOcr(use_angle_cls=True, use_gpu=False, use_table_recognition=True)
-    return table_model_api
-
-
-def get_layout_model(model_type="pp_layout_cdla", conf_thresh=0.5, iou_thresh=0.5):
-    key = (model_type, float(conf_thresh), float(iou_thresh))
-    if key not in layout_models_api:
-        layout_models_api[key] = ONNXPaddleOcr(
-            use_layout_analysis=True,
-            use_gpu=False,
-            layout_model_type=model_type,
-            layout_conf_thresh=float(conf_thresh),
-            layout_iou_thresh=float(iou_thresh),
-        )
-    return layout_models_api[key]
-
-
-def get_layout_markdown_converter(model_type="pp_doclayoutv2", conf_thresh=0.4, iou_thresh=0.5):
-    key = (model_type, float(conf_thresh), float(iou_thresh))
-    if key not in layout_markdown_converters_api:
-        layout_markdown_converters_api[key] = LayoutMarkdownConverter(
-            layout_model_type=model_type,
-            layout_conf_thresh=float(conf_thresh),
-            layout_iou_thresh=float(iou_thresh),
-            ocr_kwargs={"use_angle_cls": True, "use_gpu": False},
-        )
-    return layout_markdown_converters_api[key]
+models = ModelRegistry(use_gpu=False)
 
 
 def save_upload_file(file, session_dir):
@@ -165,33 +117,16 @@ def ocr_api():
     data = request.get_json()
     if not data or "image" not in data:
         return jsonify({"error": "Invalid request, 'image' field is required."}), 400
-    image_base64 = data["image"]
     try:
-        image_bytes = base64.b64decode(image_base64)
-        image_np = np.frombuffer(image_bytes, dtype=np.uint8)
-        img = cv2.imdecode(image_np, cv2.IMREAD_COLOR)
-        if img is None:
-            return jsonify({"error": "Failed to decode image from base64."}), 400
-    except Exception as e:
+        img = decode_base64_image(data["image"])
+    except (ValueError, Exception) as e:
         return jsonify({"error": f"Image decoding failed: {str(e)}"}), 400
     start_time = time.time()
-    result = ocr_model_api.ocr(img)
-    end_time = time.time()
-    processing_time = end_time - start_time
-    ocr_results = []
-    for line in result[0]:
-        if isinstance(line[0], (list, np.ndarray)):
-            bounding_box = np.array(line[0]).reshape(4, 2).tolist()
-        else:
-            bounding_box = []
-        ocr_results.append({
-            "text": line[1][0],
-            "confidence": float(line[1][1]),
-            "bounding_box": bounding_box
-        })
+    result = models.get_ocr_model().ocr(img)
+    processing_time = time.time() - start_time
     return jsonify({
         "processing_time": processing_time,
-        "results": ocr_results
+        "results": format_ocr_results(result)
     })
 
 @app.route("/plate_api", methods=["POST"])
@@ -205,13 +140,11 @@ def plate_api():
         return jsonify({"error": "'min_score' must be a number."}), 400
     try:
         start_time = time.time()
-        image_bytes = base64.b64decode(data["image"])
-        image_np = np.frombuffer(image_bytes, dtype=np.uint8)
-        img = cv2.imdecode(image_np, cv2.IMREAD_COLOR)
-        if img is None:
-            return jsonify({"error": "Failed to decode image from base64."}), 400
-        results = get_plate_model().ocr(img, plate_min_score=min_score)
+        img = decode_base64_image(data["image"])
+        results = models.get_plate_model().ocr(img, plate_min_score=min_score)
         processing_time = time.time() - start_time
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
     except Exception as e:
         return jsonify({"error": f"License plate recognition failed: {str(e)}"}), 500
     response = {
@@ -228,16 +161,12 @@ def table_api():
     if not data or "image" not in data:
         return jsonify({"error": "Invalid request, 'image' field is required."}), 400
     try:
-        image_bytes = base64.b64decode(data["image"])
-        image_np = np.frombuffer(image_bytes, dtype=np.uint8)
-        img = cv2.imdecode(image_np, cv2.IMREAD_COLOR)
-        if img is None:
-            return jsonify({"error": "Failed to decode image from base64."}), 400
-
+        img = decode_base64_image(data["image"])
         start_time = time.time()
-        result = get_table_model().ocr(img)
-        processing_time = time.time() - start_time
-        result["processing_time"] = processing_time
+        result = models.get_table_model().ocr(img)
+        result["processing_time"] = time.time() - start_time
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
     except Exception as e:
         return jsonify({"error": f"Table recognition failed: {str(e)}"}), 500
     if data.get("visualize", False):
@@ -252,20 +181,17 @@ def layout_api():
     if not data or "image" not in data:
         return jsonify({"error": "Invalid request, 'image' field is required."}), 400
     try:
-        image_bytes = base64.b64decode(data["image"])
-        image_np = np.frombuffer(image_bytes, dtype=np.uint8)
-        img = cv2.imdecode(image_np, cv2.IMREAD_COLOR)
-        if img is None:
-            return jsonify({"error": "Failed to decode image from base64."}), 400
-
+        img = decode_base64_image(data["image"])
         model_type = data.get("model_type", "pp_doclayoutv2")
         conf_thresh = float(data.get("conf_thresh", 0.4))
         iou_thresh = float(data.get("iou_thresh", 0.5))
         start_time = time.time()
-        result = get_layout_model(model_type, conf_thresh, iou_thresh).ocr(img)
+        result = models.get_layout_model(model_type, conf_thresh, iou_thresh).ocr(img)
         result["processing_time"] = time.time() - start_time
         if data.get("visualize", False):
             result["visualization"] = image_to_base64(draw_layout_analysis(img, result))
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
     except Exception as e:
         return jsonify({"error": f"Layout analysis failed: {str(e)}"}), 500
     return jsonify(result)
@@ -277,12 +203,7 @@ def layout_markdown_api():
     if not data or "image" not in data:
         return jsonify({"error": "Invalid request, 'image' field is required."}), 400
     try:
-        image_bytes = base64.b64decode(data["image"])
-        image_np = np.frombuffer(image_bytes, dtype=np.uint8)
-        img = cv2.imdecode(image_np, cv2.IMREAD_COLOR)
-        if img is None:
-            return jsonify({"error": "Failed to decode image from base64."}), 400
-
+        img = decode_base64_image(data["image"])
         model_type = data.get("model_type", "pp_layout_cdla")
         conf_thresh = float(data.get("conf_thresh", 0.5))
         iou_thresh = float(data.get("iou_thresh", 0.5))
@@ -294,13 +215,15 @@ def layout_markdown_api():
             filename = f"{filename}.md"
         output_md_path = os.path.join(session_dir, filename)
 
-        result = get_layout_markdown_converter(model_type, conf_thresh, iou_thresh).convert_images(
+        result = models.get_layout_markdown_converter(model_type, conf_thresh, iou_thresh).convert_images(
             [img],
             output_md_path=output_md_path,
             source_name=os.path.splitext(filename)[0],
         )
         if data.get("visualize", False):
             result["visualization"] = image_to_base64(draw_layout_analysis(img, result["pages"][0]["layout"]))
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
     except Exception as e:
         return jsonify({"error": f"Layout markdown failed: {str(e)}"}), 500
     return jsonify(result)
@@ -322,7 +245,7 @@ def layout_markdown_file():
         timestamp = time.strftime("%Y%m%d_%H%M%S")
         session_dir = os.path.join(RESULT_ROOT, timestamp)
         os.makedirs(session_dir, exist_ok=True)
-        converter = get_layout_markdown_converter(model_type, conf_thresh, iou_thresh)
+        converter = models.get_layout_markdown_converter(model_type, conf_thresh, iou_thresh)
 
         results = []
         md_files = []


### PR DESCRIPTION
- 新建 onnxocr/api_utils.py — 包含 decode_base64_image()、format_ocr_results() 和 ModelRegistry 类，集中了模型缓存和图片解码逻辑

- 重构 webui.py（378→296 行，减少 82 行）

- 删除了 4 个 get_*_model() 函数和对应的全局变量，改用 models = ModelRegistry()
5 处 base64 解码替换为 decode_base64_image()
OCR 结果格式化替换为 format_ocr_results()
- 移除了 cv2/base64/numpy/ONNXPaddleOcr/LayoutMarkdownConverter 的直接导入
- 重构 app-service.py（252→180 行，减少 72 行）
同样删除重复的模型加载函数，改用 ModelRegistry
- 5 处 base64 解码替换为 decode_base64_image()
- OCR 结果格式化替换为 format_ocr_results()
- 移除了 cv2/base64/numpy/ONNXPaddleOcr/LayoutMarkdownConverter 的直接导入
- 验证 — test_ocr.py 运行正常，OCR 功能无变化