### PR TITLE
[security] fix(webui): use unguessable result download ids

### DIFF
--- a/tests/test_webui_download_ids.py
+++ b/tests/test_webui_download_ids.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import importlib
+import io
+import os
+import re
+import sys
+import types
+import zipfile
+
+
+class FakeOCRLogic:
+    def __init__(self, status_callback):
+        self.status_callback = status_callback
+        self.model_name = None
+
+    def set_model(self, model_name):
+        self.model_name = model_name
+
+    def run(self, file_paths, save_txt, merge_txt, output_img=False):
+        for file_path in file_paths:
+            output_dir = os.path.join(os.path.dirname(file_path), "Output_OCR")
+            os.makedirs(output_dir, exist_ok=True)
+            stem = os.path.splitext(os.path.basename(file_path))[0]
+            output_path = os.path.join(output_dir, f"{stem}.txt")
+            with open(output_path, "w", encoding="utf-8") as handle:
+                handle.write("fake ocr text")
+
+
+class FakeModelRegistry:
+    def __init__(self, use_gpu=False):
+        self.use_gpu = use_gpu
+
+
+def load_webui(monkeypatch, tmp_path):
+    fake_ocr_module = types.ModuleType("onnxocr.ocr_images_pdfs")
+    setattr(fake_ocr_module, "OCRLogic", FakeOCRLogic)
+
+    fake_api_module = types.ModuleType("onnxocr.api_utils")
+    setattr(fake_api_module, "ModelRegistry", FakeModelRegistry)
+    setattr(fake_api_module, "decode_base64_image", lambda image: image)
+    setattr(fake_api_module, "format_ocr_results", lambda result: result)
+
+    fake_visualization_module = types.ModuleType("onnxocr.visualization")
+    setattr(fake_visualization_module, "draw_layout_analysis", lambda *args, **kwargs: None)
+    setattr(fake_visualization_module, "draw_plate_recognition", lambda *args, **kwargs: None)
+    setattr(fake_visualization_module, "draw_table_recognition", lambda *args, **kwargs: None)
+    setattr(fake_visualization_module, "image_to_base64", lambda image: "")
+
+    monkeypatch.setitem(sys.modules, "onnxocr.ocr_images_pdfs", fake_ocr_module)
+    monkeypatch.setitem(sys.modules, "onnxocr.api_utils", fake_api_module)
+    monkeypatch.setitem(sys.modules, "onnxocr.visualization", fake_visualization_module)
+    sys.modules.pop("webui", None)
+
+    webui = importlib.import_module("webui")
+    monkeypatch.setattr(webui, "RESULT_ROOT", str(tmp_path))
+    return webui
+
+
+def test_ocr_download_url_uses_unguessable_result_id(monkeypatch, tmp_path):
+    webui = load_webui(monkeypatch, tmp_path)
+    client = webui.app.test_client()
+
+    response = client.post(
+        "/ocr",
+        data={
+            "model_name": "PP-OCRv5",
+            "files": (io.BytesIO(b"not a real image"), "sample.png"),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    result_id = payload["zip_url"].rsplit("/", 1)[1]
+    assert re.fullmatch(r"[A-Za-z0-9_-]{22,}", result_id)
+    assert not re.fullmatch(r"\d{8}_\d{6}", result_id)
+
+    download_response = client.get(payload["zip_url"])
+    assert download_response.status_code == 200
+    assert f"ocr_txt_{result_id}.zip" in download_response.headers["Content-Disposition"]
+
+
+def test_predictable_timestamp_download_ids_are_rejected(monkeypatch, tmp_path):
+    webui = load_webui(monkeypatch, tmp_path)
+    client = webui.app.test_client()
+    timestamp = "20260101_010203"
+    legacy_dir = tmp_path / timestamp
+    legacy_dir.mkdir()
+    with zipfile.ZipFile(legacy_dir / f"ocr_txt_{timestamp}.zip", "w") as zip_file:
+        zip_file.writestr("private.txt", "private result")
+
+    response = client.get(f"/download/{timestamp}")
+
+    assert response.status_code == 404
+
+
+def test_layout_markdown_download_rejects_predictable_timestamp_ids(monkeypatch, tmp_path):
+    webui = load_webui(monkeypatch, tmp_path)
+    client = webui.app.test_client()
+    timestamp = "20260101_010203"
+    legacy_dir = tmp_path / timestamp
+    legacy_dir.mkdir()
+    with zipfile.ZipFile(
+        legacy_dir / f"layout_markdown_{timestamp}.zip", "w"
+    ) as zip_file:
+        zip_file.writestr("private.md", "# private result")
+
+    response = client.get(f"/download_layout_markdown/{timestamp}")
+
+    assert response.status_code == 404

--- a/webui.py
+++ b/webui.py
@@ -1,4 +1,5 @@
 import os
+import secrets
 import time
 import zipfile
 from flask import Flask, render_template, request, jsonify, send_file, redirect, url_for
@@ -25,6 +26,20 @@ app.config['MAX_CONTENT_LENGTH'] = 200 * 1024 * 1024  # 200MB
 
 ocr_logic = OCRLogic(lambda msg: print(msg))
 models = ModelRegistry(use_gpu=False)
+
+
+def create_result_id():
+    return secrets.token_urlsafe(16)
+
+
+def is_valid_result_id(result_id):
+    allowed_chars = all(char.isalnum() or char in "-_" for char in result_id)
+    return allowed_chars and len(result_id) >= 22
+
+
+def result_file_path(result_id, prefix):
+    filename = f"{prefix}_{result_id}.zip"
+    return os.path.join(RESULT_ROOT, result_id, filename)
 
 
 def save_upload_file(file, session_dir):
@@ -69,8 +84,8 @@ def ocr_files():
         ocr_logic.set_model(model_name)
     except Exception as e:
         return jsonify({"success": False, "msg": f"模型切换失败: {e}"}), 500
-    timestamp = time.strftime("%Y%m%d_%H%M%S")
-    session_dir = os.path.join(RESULT_ROOT, timestamp)
+    result_id = create_result_id()
+    session_dir = os.path.join(RESULT_ROOT, result_id)
     os.makedirs(session_dir, exist_ok=True)
     file_paths = []
     for file in files:
@@ -94,22 +109,23 @@ def ocr_files():
                 with open(os.path.join(out_dir, fname), "r", encoding="utf-8") as f:
                     content = f.read()
                 results.append({"filename": fname, "content": content})
-    zip_path = os.path.join(session_dir, f"ocr_txt_{timestamp}.zip")
+    zip_path = result_file_path(result_id, "ocr_txt")
     with zipfile.ZipFile(zip_path, "w") as zipf:
         for txt_file in txt_files:
             zipf.write(txt_file, os.path.basename(txt_file))
     return jsonify({
         "success": True,
         "results": results,
-        "zip_url": f"/download/{timestamp}"
+        "zip_url": f"/download/{result_id}"
     })
 
-@app.route("/download/<timestamp>")
-def download_zip(timestamp):
-    session_dir = os.path.join(RESULT_ROOT, timestamp)
-    zip_path = os.path.join(session_dir, f"ocr_txt_{timestamp}.zip")
+@app.route("/download/<result_id>")
+def download_zip(result_id):
+    if not is_valid_result_id(result_id):
+        return jsonify({"success": False, "msg": "文件不存在"}), 404
+    zip_path = result_file_path(result_id, "ocr_txt")
     if os.path.exists(zip_path):
-        return send_file(zip_path, as_attachment=True, download_name=f"ocr_txt_{timestamp}.zip")
+        return send_file(zip_path, as_attachment=True, download_name=os.path.basename(zip_path))
     return jsonify({"success": False, "msg": "文件不存在"}), 404
 
 @app.route("/ocr_api", methods=["POST"])
@@ -207,8 +223,8 @@ def layout_markdown_api():
         model_type = data.get("model_type", "pp_layout_cdla")
         conf_thresh = float(data.get("conf_thresh", 0.5))
         iou_thresh = float(data.get("iou_thresh", 0.5))
-        timestamp = time.strftime("%Y%m%d_%H%M%S")
-        session_dir = os.path.join(RESULT_ROOT, timestamp)
+        result_id = create_result_id()
+        session_dir = os.path.join(RESULT_ROOT, result_id)
         os.makedirs(session_dir, exist_ok=True)
         filename = secure_filename(data.get("filename", "layout_markdown.md")) or "layout_markdown.md"
         if not filename.lower().endswith(".md"):
@@ -242,8 +258,8 @@ def layout_markdown_file():
         model_type = request.form.get("model_type", "pp_doclayoutv2")
         conf_thresh = float(request.form.get("conf_thresh", 0.4))
         iou_thresh = float(request.form.get("iou_thresh", 0.5))
-        timestamp = time.strftime("%Y%m%d_%H%M%S")
-        session_dir = os.path.join(RESULT_ROOT, timestamp)
+        result_id = create_result_id()
+        session_dir = os.path.join(RESULT_ROOT, result_id)
         os.makedirs(session_dir, exist_ok=True)
         converter = models.get_layout_markdown_converter(model_type, conf_thresh, iou_thresh)
 
@@ -265,7 +281,7 @@ def layout_markdown_file():
                 }
             )
 
-        zip_path = os.path.join(session_dir, f"layout_markdown_{timestamp}.zip")
+        zip_path = result_file_path(result_id, "layout_markdown")
         with zipfile.ZipFile(zip_path, "w") as zipf:
             for md_path in md_files:
                 zipf.write(md_path, os.path.basename(md_path))
@@ -283,17 +299,18 @@ def layout_markdown_file():
         {
             "success": True,
             "results": results,
-            "zip_url": f"/download_layout_markdown/{timestamp}",
+            "zip_url": f"/download_layout_markdown/{result_id}",
         }
     )
 
 
-@app.route("/download_layout_markdown/<timestamp>")
-def download_layout_markdown_zip(timestamp):
-    session_dir = os.path.join(RESULT_ROOT, timestamp)
-    zip_path = os.path.join(session_dir, f"layout_markdown_{timestamp}.zip")
+@app.route("/download_layout_markdown/<result_id>")
+def download_layout_markdown_zip(result_id):
+    if not is_valid_result_id(result_id):
+        return jsonify({"success": False, "msg": "文件不存在"}), 404
+    zip_path = result_file_path(result_id, "layout_markdown")
     if os.path.exists(zip_path):
-        return send_file(zip_path, as_attachment=True, download_name=f"layout_markdown_{timestamp}.zip")
+        return send_file(zip_path, as_attachment=True, download_name=os.path.basename(zip_path))
     return jsonify({"success": False, "msg": "文件不存在"}), 404
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
This PR hardens the web UI result-download boundary so OCR output archives are no longer addressable by predictable timestamps.

- Replaces timestamp-derived result directories and download URLs with cryptographically random, URL-safe result IDs.
- Rejects legacy/predictable timestamp-shaped download IDs before file lookup for both OCR text and layout-Markdown archive endpoints.
- Keeps the returned `zip_url` flow unchanged for legitimate users while making unauthenticated guessing impractical.
- Adds regression tests for random download IDs and timestamp-ID rejection.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Predictable unauthenticated result archive URLs | A network user who can reach the web UI could guess timestamp-based `/download/...` or `/download_layout_markdown/...` URLs and retrieve another user's OCR/layout output ZIP if they know or brute-force the processing time. | Medium |

## Before this PR
- `/ocr` stored result archives under `results/<YYYYMMDD_HHMMSS>/ocr_txt_<YYYYMMDD_HHMMSS>.zip` and returned `/download/<YYYYMMDD_HHMMSS>`.
- `/layout_markdown_file` used the same timestamp pattern for `layout_markdown_<timestamp>.zip` and `/download_layout_markdown/<timestamp>`.
- The download routes did not authenticate users or require an unguessable capability token; possession of a timestamp was enough to fetch the ZIP.
- There were no regression tests preventing timestamp-based archive identifiers from being reintroduced.

## After this PR
- New result archives are placed under `results/<random-result-id>/...` where `<random-result-id>` is generated with `secrets.token_urlsafe(16)`.
- Download endpoints require URL-safe random-looking IDs of at least 22 characters, so timestamp-shaped IDs are rejected before lookup.
- Legitimate clients still receive a `zip_url` in the existing API response and can download the generated archive using that URL.
- Tests now lock in random result IDs and rejection of predictable timestamp IDs for both archive download endpoints.

## Why this matters
The result archives can contain OCR text extracted from user-uploaded documents and layout-Markdown output. In deployments where the Flask web UI is reachable by more than one user, timestamp-derived URLs turn those generated archives into unauthenticated, guessable resources.

## Attack flow
```text
network user with access to the web UI
    -> guesses a recent YYYYMMDD_HHMMSS processing timestamp
        -> requests /download/<timestamp> or /download_layout_markdown/<timestamp>
            -> route maps directly to results/<timestamp>/<prefix>_<timestamp>.zip
                -> attacker retrieves another user's generated OCR/layout archive
```

## Affected code

| Issue | Files |
|-------|-------|
| Predictable result archive URLs | `webui.py` |

## Root cause
Issue 1: Predictable unauthenticated archive identifiers
- Result directory names, ZIP names, and public download route parameters were derived from `time.strftime("%Y%m%d_%H%M%S")`.
- Download routes trusted that path component as the archive lookup key without authentication or an unguessable capability value.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Predictable unauthenticated result archive URLs | 5.3 Medium | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N` |

Rationale:
- The impact is bounded to confidentiality of generated result archives exposed by a reachable web UI instance.
- The attack does not require authentication if the web UI is exposed without an upstream auth layer.

## Safe reproduction steps
### 1. OCR text archive
1. Before this patch, submit an OCR request at a known second.
2. Request `/download/<YYYYMMDD_HHMMSS>` for that second.
3. Observe that the timestamp alone locates and returns `ocr_txt_<timestamp>.zip`.

### 2. Layout-Markdown archive
1. Before this patch, submit a layout-Markdown file request at a known second.
2. Request `/download_layout_markdown/<YYYYMMDD_HHMMSS>` for that second.
3. Observe that the timestamp alone locates and returns `layout_markdown_<timestamp>.zip`.

## Expected vulnerable behavior
- Timestamp-shaped download IDs should not be sufficient to retrieve generated result archives.
- Pre-patch behavior used the timestamp directly as the storage and download capability.
- The regression tests create timestamp-shaped legacy archive paths and verify the patched routes return 404.

## Changes in this PR
- Adds `create_result_id()` using `secrets.token_urlsafe(16)`.
- Adds `is_valid_result_id()` and rejects predictable/short IDs in download routes.
- Adds `result_file_path()` to centralize ZIP path construction.
- Updates OCR and layout-Markdown result archive creation to use random result IDs in both storage paths and returned download URLs.
- Adds `tests/test_webui_download_ids.py` covering random ID generation and rejection of timestamp-shaped download IDs.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Web UI hardening | `webui.py` | Uses unguessable result IDs for generated result archives and validates download route IDs. |
| Regression tests | `tests/test_webui_download_ids.py` | Adds Flask client tests with lightweight stubs for the web UI download behavior. |

## Maintainer impact
- The response shape remains compatible: clients still use the returned `zip_url`.
- Previously generated timestamp URLs are intentionally no longer accepted by the patched routes.
- This PR does not change OCR model behavior, upload parsing, or non-archive API endpoints.

## Fix rationale
- The download URL is the current authorization boundary for result ZIPs, so it should be an unguessable capability rather than a wall-clock timestamp.
- Random URL-safe IDs are a narrow change that avoids adding broader auth/session state while closing the predictable-ID leak.
- Regression tests cover both the positive path and the timestamp rejection behavior.

## Type of change
- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] `python -m pytest tests/test_webui_download_ids.py -q`
- [x] `python -m compileall -q webui.py tests/test_webui_download_ids.py`

Executed with:
- `python -m pytest tests/test_webui_download_ids.py -q`
- `python -m compileall -q webui.py tests/test_webui_download_ids.py`

## Disclosure notes
- This is a code-review and local-regression-test finding; no production instance was tested.
- Severity assumes a deployment where the Flask web UI is reachable by multiple users or by unauthenticated network clients.
- No unrelated files were changed.
